### PR TITLE
Added Long Term Memory using mem0 - needs testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ DISCORD_TOKEN=discord_app_token
 DISCORD_GUILD_ID=discord_server_id
 OPENAI_API_KEY=openai_key
 OPENAI_MODEL=gpt-4.1-nano
+MEM0_API_KEY=your_mem0_api_key_here

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "discord.js": "^14.18.0",
     "dotenv": "^16.5.0",
+    "mem0ai": "^2.1.25",
     "openai": "^4.96.0"
   },
   "devDependencies": {

--- a/src/services/memory/index.ts
+++ b/src/services/memory/index.ts
@@ -1,0 +1,13 @@
+import MemoryClient from 'mem0ai';
+
+const mem0ApiKey = process.env.MEM0_API_KEY!;
+
+export const memoryClient = new MemoryClient({ apiKey: mem0ApiKey });
+
+export function storeLTUserMemory(userId: string, messages: { role: string, content: string }[], metadata?: Record<string, any>) {
+  return memoryClient.add(messages, { user_id: userId, ...(metadata ? { metadata } : {}) });
+}
+
+export function retrieveLTUserMemory(userId: string, query: string) {
+  return memoryClient.search(query, { user_id: userId, output_format: "v1.1" });
+}


### PR DESCRIPTION
- Added long term memory support: Store and Retrieve
- Store is triggered after each user prompt/interaction. It should effectively store any useful memories.
- Retrieve is done before calling OpenAI. It tries to find any relevant memories, which are injected in the prompt.
- Requires mem0 API key in .env

