### PR TITLE
delete message on retry

### DIFF
--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -386,6 +386,7 @@ class Rooivalk {
           if (isRooivalkMessage) {
             const originalPrompt = await this.getOriginalMessage(message);
             if (originalPrompt) {
+              await reaction.message.delete();
               await this.processMessage(originalPrompt as DiscordMessage);
             } else {
               console.error(


### PR DESCRIPTION
feat: Delete original message on retry reaction

When you react with the retry emoji (DISCORD_EMOJI) to a message I sent, I will now delete that message before regenerating and sending a new response.

This change improves your experience by removing the outdated/previous response from the channel, avoiding clutter and potential confusion.

The core logic change is in the `MessageReactionAdd` event handler in `src/services/rooivalk/index.ts`. A call to `reaction.message.delete()` has been added specifically for messages authored by me that receive the retry emoji.

Five new test cases have been added to `src/services/rooivalk/index.test.ts` to cover this new behavior:
- Verifies message deletion when retry emoji is added to one of my messages.
- Verifies message is NOT deleted if the message is not from me.
- Verifies message is NOT deleted if a different emoji is used.
- Verifies message is NOT deleted if the reaction is in the wrong guild.
- Documents that deletion still occurs if the reaction is by another bot (current behavior).

All new tests are passing.