### PR TITLE
Fix image command errors

### DIFF
--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -166,9 +166,16 @@ class Rooivalk {
     } catch (error) {
       console.error('Error handling image command:', error);
 
-      await interaction.editReply({
-        content: this._discord.getRooivalkResponse('error'),
-      });
+      const errorMessage = this._discord.getRooivalkResponse('error');
+      if (error instanceof Error) {
+        await interaction.editReply({
+          content: `${errorMessage}\n\n\`\`\`${error.message}\`\`\``,
+        });
+      } else {
+        await interaction.editReply({
+          content: errorMessage,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- show OpenAI error details when `/image` fails
- test `/image` command error handling
- fix missing import in `index.test.ts`

## Testing
- `yarn format` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*