### PR TITLE
Improve message lookup and thread creation

### DIFF
--- a/src/services/discord/index.test.ts
+++ b/src/services/discord/index.test.ts
@@ -1,6 +1,10 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import type { MockInstance } from 'vitest';
-import { Client as DiscordClient, TextChannel } from 'discord.js';
+import {
+  Client as DiscordClient,
+  TextChannel,
+  type MessageReference,
+} from 'discord.js';
 
 import { createMockMessage } from '@/test-utils/createMockMessage';
 import { MOCK_CONFIG } from '@/test-utils/mock';
@@ -126,6 +130,7 @@ describe('DiscordService', () => {
         (
           msg.channel.messages.fetch as unknown as MockInstance
         ).mockRejectedValueOnce(new Error('fail'));
+
         expect(await service.getReferencedMessage(msg)).toBeNull();
       });
     });
@@ -134,13 +139,17 @@ describe('DiscordService', () => {
       it('walks the reply chain to find the first message', async () => {
         const root = createMockMessage();
         const mid = createMockMessage({
-          reference: { messageId: 'root' },
-          channel: { messages: { fetch: vi.fn().mockResolvedValue(root) } } as any,
-        });
+          reference: { messageId: 'root' } as MessageReference,
+          channel: {
+            messages: { fetch: vi.fn().mockResolvedValue(root) },
+          } as any,
+        } as Partial<DiscordMessage>);
         const msg = createMockMessage({
-          reference: { messageId: 'mid' },
-          channel: { messages: { fetch: vi.fn().mockResolvedValue(mid) } } as any,
-        });
+          reference: { messageId: 'mid' } as MessageReference,
+          channel: {
+            messages: { fetch: vi.fn().mockResolvedValue(mid) },
+          } as any,
+        } as Partial<DiscordMessage>);
         const result = await service.getOriginalMessage(msg);
         expect(result).toBe(root);
       });

--- a/src/services/discord/index.ts
+++ b/src/services/discord/index.ts
@@ -223,7 +223,7 @@ export class DiscordService {
         return null;
       }
 
-      let current: DiscordMessage = await message.channel.messages.fetch(
+      let current = await message.channel.messages.fetch(
         message.reference.messageId
       );
       let depth = 0;

--- a/src/services/discord/index.ts
+++ b/src/services/discord/index.ts
@@ -198,13 +198,47 @@ export class DiscordService {
     return messageChain;
   }
 
-  public async getOriginalMessage(message: DiscordMessage) {
+  /**
+   * Fetches the message being replied to.
+   */
+  public async getReferencedMessage(message: DiscordMessage) {
     try {
       const reference = message.reference;
       if (!reference?.messageId) {
         return null;
       }
       return await message.channel.messages.fetch(reference.messageId);
+    } catch (error) {
+      console.error('Error fetching referenced message:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Walks up the reply chain to find the first message in the conversation.
+   */
+  public async getOriginalMessage(message: DiscordMessage) {
+    try {
+      if (!message.reference?.messageId) {
+        return null;
+      }
+
+      let current: DiscordMessage = await message.channel.messages.fetch(
+        message.reference.messageId
+      );
+      let depth = 0;
+
+      while (
+        current.reference?.messageId &&
+        depth < DISCORD_MAX_MESSAGE_CHAIN_LENGTH
+      ) {
+        current = await current.channel.messages.fetch(
+          current.reference.messageId
+        );
+        depth += 1;
+      }
+
+      return current;
     } catch (error) {
       console.error('Error fetching original message:', error);
       return null;
@@ -258,7 +292,7 @@ export class DiscordService {
     message: DiscordMessage
   ): Promise<string | null> {
     if (message.reference && message.reference.messageId) {
-      const repliedToMessage = await this.getOriginalMessage(message);
+      const repliedToMessage = await this.getReferencedMessage(message);
       if (
         repliedToMessage &&
         repliedToMessage.author.id === this._discordClient.user?.id

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -85,6 +85,27 @@ class OpenAIClient {
       throw new Error('Error creating image');
     }
   }
+
+  async generateThreadName(prompt: string) {
+    try {
+      const response = await this._openai.responses.create({
+        model: this._model,
+        tools: this._tools,
+        instructions:
+          'Provide a short title for this conversation in five words or less.',
+        input: prompt,
+      });
+
+      return response.output_text.trim();
+    } catch (error) {
+      console.error('Error with OpenAI:', error);
+      if (error instanceof OpenAI.OpenAIError) {
+        throw new Error(error.message);
+      }
+
+      throw new Error('Error creating thread name');
+    }
+  }
 }
 
 export default OpenAIClient;

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -58,11 +58,7 @@ describe('Rooivalk', () => {
       configurable: true,
     });
 
-    rooivalk = new Rooivalk(
-      MOCK_CONFIG,
-      mockDiscordService,
-      mockOpenAIClient
-    );
+    rooivalk = new Rooivalk(MOCK_CONFIG, mockDiscordService, mockOpenAIClient);
   });
 
   afterEach(() => {
@@ -75,7 +71,9 @@ describe('Rooivalk', () => {
         const userMessage = createMockMessage({
           content: `<@${BOT_ID}> Hi!`,
         } as Partial<DiscordMessage>);
-        mockDiscordService.buildPromptFromMessageChain.mockResolvedValue('User: Hi!\nRooivalk: Hello!');
+        mockDiscordService.buildPromptFromMessageChain.mockResolvedValue(
+          'User: Hi!\nRooivalk: Hello!'
+        );
         await (rooivalk as any).processMessage(userMessage);
         expect(
           mockDiscordService.buildPromptFromMessageChain
@@ -87,13 +85,14 @@ describe('Rooivalk', () => {
       });
     });
 
-
     describe('Rooivalk private shouldProcessMessage', () => {
       it('returns true for whitelisted bot', () => {
         const allowedBotId = 'allowed-bot-id';
         // Set up environment with allowed bot ID
-        vi.stubGlobal('process', { env: { ...MOCK_ENV, DISCORD_ALLOWED_APPS: allowedBotId } });
-        
+        vi.stubGlobal('process', {
+          env: { ...MOCK_ENV, DISCORD_ALLOWED_APPS: allowedBotId },
+        });
+
         // Create new instance with updated environment
         const testRooivalk = new Rooivalk(
           MOCK_CONFIG,
@@ -103,7 +102,7 @@ describe('Rooivalk', () => {
 
         const msg = Object.assign(createMockMessage(), {
           author: { id: allowedBotId, bot: true } as any,
-          guild: { id: 'guild-id' } as any
+          guild: { id: 'guild-id' } as any,
         });
         // @ts-expect-error: testing private method
         expect(testRooivalk.shouldProcessMessage(msg, 'guild-id')).toBe(true);
@@ -112,7 +111,7 @@ describe('Rooivalk', () => {
       it('returns false for non-whitelisted bot', () => {
         const msg = Object.assign(createMockMessage(), {
           author: { id: 'not-allowed-bot-id', bot: true } as any,
-          guild: { id: 'guild-id' } as any
+          guild: { id: 'guild-id' } as any,
         });
         // @ts-expect-error: testing private method
         expect(rooivalk.shouldProcessMessage(msg, 'guild-id')).toBe(false);
@@ -121,8 +120,10 @@ describe('Rooivalk', () => {
       it('returns false for wrong guild', () => {
         const allowedBotId = 'allowed-bot-id';
         // Set up environment with allowed bot ID
-        vi.stubGlobal('process', { env: { ...MOCK_ENV, DISCORD_ALLOWED_APPS: allowedBotId } });
-        
+        vi.stubGlobal('process', {
+          env: { ...MOCK_ENV, DISCORD_ALLOWED_APPS: allowedBotId },
+        });
+
         // Create new instance with updated environment
         const testRooivalk = new Rooivalk(
           MOCK_CONFIG,
@@ -132,7 +133,7 @@ describe('Rooivalk', () => {
 
         const msg = Object.assign(createMockMessage(), {
           author: { id: allowedBotId, bot: true } as any,
-          guild: { id: 'other-guild' } as any
+          guild: { id: 'other-guild' } as any,
         });
         // @ts-expect-error: testing private method
         expect(testRooivalk.shouldProcessMessage(msg, 'guild-id')).toBe(false);
@@ -141,13 +142,12 @@ describe('Rooivalk', () => {
       it('returns true for a user (not a bot)', () => {
         const msg = Object.assign(createMockMessage(), {
           author: { id: 'user-id', bot: false } as any,
-          guild: { id: 'guild-id' } as any
+          guild: { id: 'guild-id' } as any,
         });
         // @ts-expect-error: testing private method
         expect(rooivalk.shouldProcessMessage(msg, 'guild-id')).toBe(true);
       });
     });
-
 
     describe('and buildPromptFromMessageChain returns null', () => {
       it('should use message content if buildPromptFromMessageChain returns null', async () => {
@@ -200,7 +200,9 @@ describe('Rooivalk', () => {
           content: `<@${BOT_ID}> Fail!`,
         } as Partial<DiscordMessage>);
         mockDiscordService.buildPromptFromMessageChain.mockResolvedValue(null);
-        mockOpenAIClient.createResponse.mockRejectedValue(new Error('OpenAI error!'));
+        mockOpenAIClient.createResponse.mockRejectedValue(
+          new Error('OpenAI error!')
+        );
         await (rooivalk as any).processMessage(userMessage);
         expect(userMessage.reply).toHaveBeenCalledWith(
           expect.stringContaining('OpenAI error!')
@@ -229,7 +231,9 @@ describe('Rooivalk', () => {
 
       mockDiscordService.buildPromptFromMessageChain.mockResolvedValue('chain');
       mockDiscordService.getReferencedMessage.mockResolvedValueOnce(botReply);
-      mockDiscordService.getOriginalMessage.mockResolvedValueOnce(originalMessage);
+      mockDiscordService.getOriginalMessage.mockResolvedValueOnce(
+        originalMessage
+      );
 
       const thread = await (rooivalk as any).maybeCreateThread(userMessage);
       expect(mockOpenAIClient.generateThreadName).toHaveBeenCalledWith('chain');
@@ -255,7 +259,9 @@ describe('Rooivalk', () => {
         reference: { messageId: '2' },
       } as any);
       mockDiscordService.getReferencedMessage.mockResolvedValueOnce(botReply);
-      mockDiscordService.getOriginalMessage.mockResolvedValueOnce(originalMessage);
+      mockDiscordService.getOriginalMessage.mockResolvedValueOnce(
+        originalMessage
+      );
       const thread = await (rooivalk as any).maybeCreateThread(userMessage);
       expect(startThread).not.toHaveBeenCalled();
       expect(thread).toBe(existingThread);
@@ -323,10 +329,16 @@ describe('Rooivalk', () => {
       } as unknown as ChatInputCommandInteraction;
 
       mockOpenAIClient.createImage.mockResolvedValue('img');
-      mockDiscordService.buildImageReply.mockReturnValue({ embeds: ['e'], files: ['f'] });
+      mockDiscordService.buildImageReply.mockReturnValue({
+        embeds: ['e'],
+        files: ['f'],
+      });
 
       await (rooivalk as any).handleImageCommand(interaction);
-      expect(interaction.editReply).toHaveBeenCalledWith({ embeds: ['e'], files: ['f'] });
+      expect(interaction.editReply).toHaveBeenCalledWith({
+        embeds: ['e'],
+        files: ['f'],
+      });
     });
 
     it('should reply with error details if OpenAI throws', async () => {

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -26,7 +26,10 @@ class Rooivalk {
     // Parse DISCORD_ALLOWED_APPS once and store
     const allowedAppsEnv = process.env.DISCORD_ALLOWED_APPS;
     this._allowedAppIds = allowedAppsEnv
-      ? allowedAppsEnv.split(',').map((id) => id.trim()).filter(Boolean)
+      ? allowedAppsEnv
+          .split(',')
+          .map((id) => id.trim())
+          .filter(Boolean)
       : [];
   }
 
@@ -40,7 +43,8 @@ class Rooivalk {
     guildId: string
   ): boolean {
     if (
-      (message.author.bot && !this._allowedAppIds.includes(message.author.id)) ||
+      (message.author.bot &&
+        !this._allowedAppIds.includes(message.author.id)) ||
       message.guild?.id !== guildId
     ) {
       return false;
@@ -74,7 +78,9 @@ class Rooivalk {
       }
 
       // find the original user message
-      const original = await this._discord.getOriginalMessage(reply);
+      const original = await this._discord.getOriginalMessage(
+        reply as DiscordMessage
+      );
       if (!original) {
         return null;
       }
@@ -280,10 +286,7 @@ class Rooivalk {
 
       this._discord.on(DiscordEvents.MessageCreate, async (message) => {
         if (
-          !this.shouldProcessMessage(
-            message,
-            process.env.DISCORD_GUILD_ID!
-          )
+          !this.shouldProcessMessage(message, process.env.DISCORD_GUILD_ID!)
         ) {
           return;
         }

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -57,7 +57,53 @@ class Rooivalk {
     this._openaiClient.reloadConfig(newConfig);
   }
 
+  /**
+   * Checks if a message is replying to the bot and, if so, creates a thread on
+   * the original user message.
+   */
+  private async maybeCreateThread(message: DiscordMessage) {
+    if (message.author.bot || !message.reference?.messageId) {
+      return null;
+    }
+
+    try {
+      // fetch the message the user replied to
+      const reply = await this._discord.getReferencedMessage(message);
+      if (!reply || reply.author.id !== this._discord.client.user?.id) {
+        return null;
+      }
+
+      // find the original user message
+      const original = await this._discord.getOriginalMessage(reply);
+      if (!original) {
+        return null;
+      }
+
+      if (original.hasThread) {
+        return original.thread ?? null;
+      }
+
+      try {
+        const namePrompt =
+          (await this._discord.buildPromptFromMessageChain(message)) ||
+          message.content;
+        const threadName =
+          (await this._openaiClient.generateThreadName(namePrompt)) ||
+          'Conversation with Rooivalk';
+        return await (original as any).startThread({ name: threadName });
+      } catch (err) {
+        console.error('Failed to create thread:', err);
+        return null;
+      }
+    } catch (err) {
+      console.error('Error handling thread creation:', err);
+      return null;
+    }
+  }
+
   private async processMessage(message: DiscordMessage) {
+    const thread = await this.maybeCreateThread(message);
+
     try {
       let prompt = message.content
         .replace(this._discord.mentionRegex!, '')
@@ -87,9 +133,17 @@ class Rooivalk {
           response,
           usersToMention.map((user) => user.id)
         );
-        await message.reply(reply);
+        if (thread) {
+          await thread.send(reply);
+        } else {
+          await message.reply(reply);
+        }
       } else {
-        await message.reply(this._discord.getRooivalkResponse('error'));
+        if (thread) {
+          await thread.send(this._discord.getRooivalkResponse('error'));
+        } else {
+          await message.reply(this._discord.getRooivalkResponse('error'));
+        }
       }
     } catch (error) {
       console.error('Error processing message:', error);
@@ -99,7 +153,11 @@ class Rooivalk {
         error instanceof Error
           ? `${errorMessage}\n\n\`\`\`${error.message}\`\`\``
           : errorMessage;
-      await message.reply(reply);
+      if (thread) {
+        await thread.send(reply);
+      } else {
+        await message.reply(reply);
+      }
       return;
     }
   }


### PR DESCRIPTION
## Summary
- add `getReferencedMessage` helper and make `getOriginalMessage` walk the reply chain
- update `maybeCreateThread` to rely on these new helpers
- adjust tests for updated logic

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684931b692208326b58e9d8cb1902161