### PR TITLE
Improve thread creation UX

### DIFF
--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -320,13 +320,16 @@ describe('Rooivalk', () => {
         options: { getString: vi.fn().mockReturnValue('prompt') },
         deferReply: vi.fn(),
         editReply: vi.fn(),
-        deleteReply: vi.fn(),
         channel: {
           threads: { create: vi.fn() },
         },
+        user: {
+          username: 'alice',
+          toString: () => '<@123>',
+        },
       } as unknown as ChatInputCommandInteraction;
 
-      const mockThread = { send: vi.fn() } as any;
+      const mockThread = { send: vi.fn(), url: 'thread-url' } as any;
       (interaction.channel as any).threads.create.mockResolvedValue(mockThread);
 
       const longResponse = 'a'.repeat(4500);
@@ -341,8 +344,11 @@ describe('Rooivalk', () => {
 
       expect(mockThread.send).toHaveBeenCalledTimes(4);
       expect(mockThread.send).toHaveBeenNthCalledWith(1, '>>> prompt');
-      expect(interaction.deleteReply).toHaveBeenCalled();
-      expect(interaction.editReply).not.toHaveBeenCalled();
+      expect(interaction.deferReply).toHaveBeenCalled();
+
+      expect(interaction.editReply).toHaveBeenCalledWith({
+        content: '<@123> created a thread.\n>>> prompt',
+      });
     });
   });
 

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -1,4 +1,4 @@
-import { Events as DiscordEvents } from 'discord.js';
+import { Events as DiscordEvents, EmbedBuilder } from 'discord.js';
 import type {
   ChatInputCommandInteraction,
   Interaction,
@@ -228,7 +228,7 @@ class Rooivalk {
     interaction: ChatInputCommandInteraction
   ): Promise<void> {
     const prompt = interaction.options.getString('prompt', true);
-    await interaction.deferReply({ ephemeral: true });
+    await interaction.deferReply();
 
     try {
       const threadName =
@@ -266,7 +266,10 @@ class Rooivalk {
             console.error('Error sending chunk to thread:', error);
           }
         }
-        await interaction.deleteReply();
+
+        await interaction.editReply({
+          content: `${interaction.user} created a thread.\n>>> ${prompt}`,
+        });
       } else {
         await interaction.editReply({
           content: this._discord.getRooivalkResponse('error'),


### PR DESCRIPTION
## Summary
- update thread reply to mention user and show prompt
- adjust thread command test accordingly

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684d3da17e848326a56f93ecf0bc935b