### PR TITLE
Improve config loading speed

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -61,15 +61,30 @@ export const loadInstructions = async (filename: string): Promise<string> => {
 };
 
 export const loadConfig = async (): Promise<InMemoryConfig> => {
+  const [
+    errorMessages,
+    greetingMessages,
+    discordLimitMessages,
+    instructionsRooivalk,
+    instructionsLearn,
+    motd,
+  ] = await Promise.all([
+    loadMessageList(CONFIG_FILE_ERRORS),
+    loadMessageList(CONFIG_FILE_GREETINGS),
+    loadMessageList(CONFIG_FILE_DISCORD_LIMIT),
+    loadInstructions(CONFIG_FILE_INSTRUCTIONS_ROOIVALK),
+    loadInstructions(CONFIG_FILE_INSTRUCTIONS_LEARN),
+    loadInstructions(CONFIG_FILE_MOTD),
+  ]);
+
   const config: InMemoryConfig = {
-    errorMessages: await loadMessageList(CONFIG_FILE_ERRORS),
-    greetingMessages: await loadMessageList(CONFIG_FILE_GREETINGS),
-    discordLimitMessages: await loadMessageList(CONFIG_FILE_DISCORD_LIMIT),
-    instructionsRooivalk: await loadInstructions(
-      CONFIG_FILE_INSTRUCTIONS_ROOIVALK
-    ),
-    instructionsLearn: await loadInstructions(CONFIG_FILE_INSTRUCTIONS_LEARN),
-    motd: await loadInstructions(CONFIG_FILE_MOTD),
+    errorMessages,
+    greetingMessages,
+    discordLimitMessages,
+    instructionsRooivalk,
+    instructionsLearn,
+    motd,
   };
+
   return config;
 };


### PR DESCRIPTION
## Summary
- parallelize config loading with `Promise.all`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684d43fdc3408326bf93be38987d2f58