### PR TITLE
Add upcoming events cron tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,15 @@ The codebase uses a modular service-based architecture, grouping responsibilitie
 
 ```bash
 rooivalk/
+├── .editorconfig
+├── .env.example
+├── .gitattributes
+├── .github/
+├── .gitignore
+├── .nvmrc
+├── .prettierrc
+├── AGENTS.md
+├── README.md
 ├── src/
 │   ├── constants.ts            # Global constants
 │   ├── index.ts                # Main entry point
@@ -50,13 +59,12 @@ rooivalk/
 ├── scripts/                    # Build helpers
 │   ├── postbuild.mjs
 │   └── resolve-ts-paths-loader.mjs
+├── tsconfig.json               # TypeScript configuration
 ├── vitest.config.ts            # Vitest configuration
 ├── vitest.setup.ts             # Test setup hooks
 ├── package.json                # Node.js package configuration
-├── tsconfig.json               # TypeScript configuration
-├── .env.example                # Environment variable example file
 ├── yarn.lock                   # Yarn lockfile
-└── README.md                   # Project documentation
+└── node_modules/               # Installed dependencies
 ```
 
 ## Architectural Notes

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,13 @@ async function main() {
     await rooivalk.sendTodaysEvents();
   });
 
-  cron.schedule('0 8 * * 1', () => rooivalk.sendWeeklyEvents());
+  cron.schedule('0 8 * * 1', async () => {
+    try {
+      await rooivalk.sendWeeklyEvents();
+    } catch (error) {
+      console.error('Failed to send weekly events:', error);
+    }
+  });
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,12 @@ async function main() {
 
   const cron = new Cron(rooivalk);
   const motdExpr = process.env.ROOIVALK_MOTD_CRON || DEFAULT_CRON;
-  cron.schedule(motdExpr, () => rooivalk.sendMotdToMotdChannel());
+  cron.schedule(motdExpr, async () => {
+    await rooivalk.sendMotdToMotdChannel();
+    await rooivalk.sendTodaysEvents();
+  });
+
+  cron.schedule('0 8 * * 1', () => rooivalk.sendWeeklyEvents());
 }
 
 main().catch((error) => {

--- a/src/services/discord/index.ts
+++ b/src/services/discord/index.ts
@@ -172,6 +172,27 @@ export class DiscordService {
     };
   }
 
+  public async fetchScheduledEventsBetween(
+    start: Date,
+    end: Date
+  ): Promise<{ name: string; date: Date }[]> {
+    try {
+      const guild = await this._discordClient.guilds.fetch(
+        process.env.DISCORD_GUILD_ID!
+      );
+      const events = await guild.scheduledEvents.fetch();
+      return Array.from(events.values())
+        .filter((event) => {
+          const date = event.scheduledStartAt;
+          return date && date >= start && date < end;
+        })
+        .map((event) => ({ name: event.name, date: event.scheduledStartAt! }));
+    } catch (error) {
+      console.error('Error fetching scheduled events:', error);
+      return [];
+    }
+  }
+
   public async getMessageChain(
     currentMessage: DiscordMessage
   ): Promise<{ author: 'user' | 'rooivalk'; content: string }[]> {

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -22,6 +22,7 @@ const mockDiscordService = vi.mocked({
   buildImageReply: vi.fn().mockReturnValue({ embeds: [], files: [] }),
   chunkContent: vi.fn(),
   getRooivalkResponse: vi.fn().mockReturnValue('Error!'),
+  fetchScheduledEventsBetween: vi.fn(),
   buildPromptFromMessageChain: vi.fn(),
   registerSlashCommands: vi.fn(),
   sendReadyMessage: vi.fn(),


### PR DESCRIPTION
## Summary
- load events from the guild
- expose `fetchScheduledEventsBetween` in DiscordService
- notify about weekly and daily events via RooivalkService
- watch only markdown config files
- format event list outside of the OpenAI prompt

## Testing
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686f71e32f04832688142ad01f817a0f