### PR TITLE
Add CONFIG_DIR constant module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Other files and directories follow standard Node.js/TypeScript project conventio
 - Global constants: `src/constants.ts`
 - Shared types: `src/types.ts`
 - Service-specific constants: `services/<service>/constants.ts`
+- Config directory resolver: `src/config/constants.ts`
 
 ### Environment
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,9 @@
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// ESM-compatible __filename and __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Directory where config markdown files are located (relative to dist or src)
+export const CONFIG_DIR = join(__dirname, '..', '..', 'config');

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'fs/promises';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
+
+import { CONFIG_DIR } from './constants';
 
 import {
   CONFIG_FILE_ERRORS,
@@ -11,13 +12,6 @@ import {
   CONFIG_FILE_MOTD,
 } from '@/constants';
 import type { InMemoryConfig } from '@/types';
-
-// ESM-compatible __filename and __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Directory where config markdown files are located (relative to dist or src)
-const CONFIG_DIR = join(__dirname, '..', '..', 'config');
 
 export const getConfigFilePath = (filename: string): string =>
   join(CONFIG_DIR, filename);

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -1,14 +1,8 @@
 import { existsSync, watch } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+
+import { CONFIG_DIR } from './constants';
 
 export type ConfigReloadCallback = (changedFile: string) => void;
-
-// ESM-compatible __filename and __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const CONFIG_DIR = join(__dirname, '..', '..', 'config');
 
 /**
  * Watches the config directory for changes to .md files and triggers the callback.


### PR DESCRIPTION
## Summary
- export CONFIG_DIR resolver in `src/config/constants.ts`
- reuse CONFIG_DIR in config loader and watcher
- document config path constant in AGENTS.md

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6889dc5bcb348326a8086aa3b9dfb105