### PR TITLE
Add console mock helpers for tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ Other files and directories follow standard Node.js/TypeScript project conventio
 
 ### Utilities & Constants
 
-- Test utilities: `src/test-utils/`
+- Test utilities: `src/test-utils/` (e.g., `createMockMessage.ts`,
+  `consoleMocks.ts`)
 - Global constants: `src/constants.ts`
 - Shared types: `src/types.ts`
 - Service-specific constants: `services/<service>/constants.ts`

--- a/src/services/discord/index.test.ts
+++ b/src/services/discord/index.test.ts
@@ -17,6 +17,7 @@ import {
 import { createMockMessage } from '@/test-utils/createMockMessage';
 import { MOCK_CONFIG } from '@/test-utils/mock';
 import type { ResponseType } from '@/types';
+import { silenceConsole } from '@/test-utils/consoleMocks';
 
 import DiscordService from '.';
 import type { DiscordMessage } from '.';
@@ -37,40 +38,21 @@ vi.mock('discord.js', async (importOriginal) => {
 
 const BOT_ID = 'test-bot-id';
 
-// Silence expected error logs for specific known error messages
-let errorSpy: ReturnType<typeof vi.spyOn>;
-let logSpy: ReturnType<typeof vi.spyOn>;
+let restoreConsole: () => void;
 
 beforeAll(() => {
-  errorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
-    if (
-      typeof args[0] === 'string' &&
-      (args[0].includes('Error sending ready message') ||
-        args[0].includes('Error fetching referenced message') ||
-        args[0].includes('Error fetching original message'))
-    ) {
-      return;
-    }
-    // Uncomment the next line to allow unexpected errors to show:
-    // errorSpy.mockRestore(); console.error(...args);
-  });
-
-  logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
-    if (
-      typeof args[0] === 'string' &&
-      (args[0].includes('Successfully registered slash commands.') ||
-        args[0].includes('🤖 Logged in as'))
-    ) {
-      return;
-    }
-    // Uncomment the next line to allow unexpected logs to show:
-    // logSpy.mockRestore(); console.log(...args);
+  restoreConsole = silenceConsole({
+    ignoreErrors: [
+      'Error sending ready message',
+      'Error fetching referenced message',
+      'Error fetching original message',
+    ],
+    ignoreLogs: ['Successfully registered slash commands.', '🤖 Logged in as'],
   });
 });
 
 afterAll(() => {
-  errorSpy.mockRestore();
-  logSpy.mockRestore();
+  restoreConsole();
 });
 
 function createMockDiscordClient() {

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -8,41 +8,19 @@ import {
   beforeAll,
   afterAll,
 } from 'vitest';
+import { silenceConsole } from '@/test-utils/consoleMocks';
 
-let errorSpy: ReturnType<typeof vi.spyOn>;
-let logSpy: ReturnType<typeof vi.spyOn>;
+let restoreConsole: () => void;
 
 beforeAll(() => {
-  errorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
-    if (
-      typeof args[0] === 'string' &&
-      (args[0].includes('OpenAI error!') ||
-        args[0].includes('Startup channel ID not set') ||
-        args[0].includes('blocked'))
-    ) {
-      return;
-    }
-    // Optionally, call the original if you want to see other errors:
-    // errorSpy.mockRestore();
-    // console.error(...args);
-  });
-  logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
-    if (
-      typeof args[0] === 'string' &&
-      (args[0].includes('🤖 Logged in as') ||
-        args[0].includes('Successfully registered slash commands.'))
-    ) {
-      return;
-    }
-    // Optionally, call the original if you want to see other logs:
-    // logSpy.mockRestore();
-    // console.log(...args);
+  restoreConsole = silenceConsole({
+    ignoreErrors: ['OpenAI error!', 'Startup channel ID not set', 'blocked'],
+    ignoreLogs: ['🤖 Logged in as', 'Successfully registered slash commands.'],
   });
 });
 
 afterAll(() => {
-  errorSpy.mockRestore();
-  logSpy.mockRestore();
+  restoreConsole();
 });
 
 import type { DiscordMessage } from '@/services/discord';

--- a/src/test-utils/consoleMocks.ts
+++ b/src/test-utils/consoleMocks.ts
@@ -1,0 +1,44 @@
+import { vi } from 'vitest';
+
+export interface ConsoleMockOptions {
+  ignoreErrors?: string[];
+  ignoreLogs?: string[];
+}
+
+export function silenceConsole(options: ConsoleMockOptions = {}) {
+  const originalError = console.error;
+  const originalLog = console.log;
+
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (
+      options.ignoreErrors?.some((msg) =>
+        args.some(
+          (arg) =>
+            (typeof arg === 'string' && arg.includes(msg)) ||
+            (arg instanceof Error && arg.message.includes(msg))
+        )
+      )
+    ) {
+      return;
+    }
+
+    originalError(...args);
+  });
+
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    if (
+      options.ignoreLogs?.some((msg) =>
+        args.some((arg) => typeof arg === 'string' && arg.includes(msg))
+      )
+    ) {
+      return;
+    }
+
+    originalLog(...args);
+  });
+
+  return function restoreConsole() {
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  };
+}


### PR DESCRIPTION
## Summary
- add `silenceConsole` helper in `src/test-utils/consoleMocks.ts`
- use the helper in DiscordService and Rooivalk tests
- document the helper in `AGENTS.md`
- improve console mocking to restore originals and match errors in all arguments

## Testing
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6889dc4e57988326b2699d69255620cd