### PR TITLE
Add thread auto-start on bot replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Other files and directories follow standard Node.js/TypeScript project conventio
 
 #### RooivalkService
 - Core business logic: processes messages, prepares prompts, integrates weather/events, shapes responses, manages context.
+- Automatically starts a new thread when a user replies to a bot message without one and continues conversations in that thread.
+- Messages inside bot-owned threads do not require a mention to be processed.
 
 ### Utilities & Constants
 

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -388,6 +388,76 @@ describe('Rooivalk', () => {
     });
   });
 
+  describe('message create thread behavior', () => {
+    it('creates a thread when replying to bot without one', async () => {
+      let messageHandler: (msg: DiscordMessage) => Promise<void>;
+      mockDiscordService.on.mockImplementation((event: string, cb: any) => {
+        if (event === 'messageCreate') messageHandler = cb;
+        return mockDiscordService;
+      });
+      mockDiscordService.once.mockImplementation((event: string, cb: any) => {
+        if (event === 'ready') cb();
+        return mockDiscordService;
+      });
+
+      await rooivalk.init();
+
+      const thread = { members: { add: vi.fn() }, send: vi.fn() } as any;
+      const botMessage = createMockMessage({
+        author: { id: BOT_ID, bot: true } as any,
+        hasThread: false,
+        startThread: vi.fn().mockResolvedValue(thread),
+        guild: { id: MOCK_ENV.DISCORD_GUILD_ID } as any,
+      });
+
+      mockDiscordService.getReferencedMessage.mockResolvedValue(botMessage);
+
+      const userMessage = createMockMessage({
+        content: `<@${BOT_ID}> hello`,
+        reference: { messageId: '1' } as any,
+        channel: { isThread: () => false, messages: { fetch: vi.fn() } },
+        guild: { id: MOCK_ENV.DISCORD_GUILD_ID } as any,
+      } as Partial<DiscordMessage>);
+
+      await messageHandler!(userMessage);
+
+      expect(mockOpenAIClient.generateThreadName).toHaveBeenCalledWith('hello');
+      expect(botMessage.startThread).toHaveBeenCalledWith({
+        name: 'Thread Title',
+        autoArchiveDuration: 60,
+      });
+      expect(thread.members.add).toHaveBeenCalledWith(userMessage.author.id);
+      expect(thread.send).toHaveBeenCalledWith('>>> hello');
+      expect(mockOpenAIClient.createResponse).toHaveBeenCalled();
+    });
+
+    it('processes messages in bot-owned threads without mention', async () => {
+      let messageHandler: (msg: DiscordMessage) => Promise<void>;
+      mockDiscordService.on.mockImplementation((event: string, cb: any) => {
+        if (event === 'messageCreate') messageHandler = cb;
+        return mockDiscordService;
+      });
+      mockDiscordService.once.mockImplementation((event: string, cb: any) => {
+        if (event === 'ready') cb();
+        return mockDiscordService;
+      });
+
+      await rooivalk.init();
+
+      const threadChannel = { isThread: () => true, ownerId: BOT_ID } as any;
+      const msg = createMockMessage({
+        content: 'hi',
+        channel: threadChannel,
+        mentions: { users: { filter: vi.fn().mockReturnValue([]) } } as any,
+        guild: { id: MOCK_ENV.DISCORD_GUILD_ID } as any,
+      } as Partial<DiscordMessage>);
+
+      await messageHandler!(msg);
+
+      expect(mockOpenAIClient.createResponse).toHaveBeenCalled();
+    });
+  });
+
   describe('when initialized', () => {
     it('should set up event handlers and call login', async () => {
       // Patch the once method to immediately call the callback for ClientReady


### PR DESCRIPTION
## Summary
- create threads when users reply to rooivalk
- allow further messages in bot-owned threads without mention
- test thread creation & thread message handling
- document thread behaviour in AGENTS.md
- improve thread handler typing

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688a233c2e708326a79ff51efec4037f