### PR TITLE
Add mention + deletion when starting bot thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ Other files and directories follow standard Node.js/TypeScript project conventio
 
 #### RooivalkService
 - Core business logic: processes messages, prepares prompts, integrates weather/events, shapes responses, manages context.
+- Automatically starts a new thread when a user replies to a bot message without one and continues conversations in that thread.
+- Messages inside bot-owned threads do not require a mention to be processed.
+- The original reply is deleted and the user is mentioned in the quoted prompt posted in the thread.
 
 ### Utilities & Constants
 

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -1,9 +1,15 @@
-import { Events as DiscordEvents, EmbedBuilder } from 'discord.js';
+import {
+  Events as DiscordEvents,
+  EmbedBuilder,
+  ThreadAutoArchiveDuration,
+  userMention,
+} from 'discord.js';
 import type {
   ChatInputCommandInteraction,
   Client,
   Interaction,
   TextChannel,
+  ThreadChannel,
 } from 'discord.js';
 
 import { DISCORD_COMMANDS, DISCORD_EMOJI } from '@/constants';
@@ -360,7 +366,13 @@ class Rooivalk {
         return;
       }
 
-      // Check if the message is a reply to the bot
+      const client = this._discord.client;
+
+      const inBotThread =
+        message.channel.isThread() &&
+        (message.channel as ThreadChannel).ownerId === client.user?.id;
+      // messages in bot-owned threads should be processed even without a mention
+
       let isReplyToBot = false;
       if (message.reference && message.reference.messageId) {
         const repliedToMessage = await this._discord.getReferencedMessage(
@@ -368,24 +380,37 @@ class Rooivalk {
         );
         if (
           repliedToMessage &&
-          repliedToMessage.author.id === this._discord.client.user?.id
+          repliedToMessage.author.id === client.user?.id
         ) {
           isReplyToBot = true;
+
+          if (!repliedToMessage.hasThread && !message.channel.isThread()) {
+            const prompt = this._discord.mentionRegex
+              ? message.content.replace(this._discord.mentionRegex, '').trim()
+              : message.content.trim();
+            const name =
+              (await this._openai.generateThreadName(prompt)) ||
+              'Conversation with rooivalk';
+            const thread = await repliedToMessage.startThread({
+              name,
+              autoArchiveDuration: ThreadAutoArchiveDuration.OneHour,
+            });
+            await thread.members.add(message.author.id);
+            await thread.send(`${userMention(message.author.id)}\n>>> ${prompt}`);
+            await message.delete();
+          }
         }
       }
 
-      // Check if the bot is mentioned directly
       const isMentioned =
         this._discord.mentionRegex &&
         this._discord.mentionRegex.test(message.content);
 
-      // If not a reply to the bot and not mentioned, ignore the message
-      if (!isReplyToBot && !isMentioned) {
+      if (!isReplyToBot && !isMentioned && !inBotThread) {
         return;
       }
 
-      // If mentionRegex is null (bot not fully initialized), and it's not a reply to the bot, ignore.
-      if (!this._discord.mentionRegex && !isReplyToBot) {
+      if (!this._discord.mentionRegex && !isReplyToBot && !inBotThread) {
         console.warn(
           'Mention regex not initialized, ignoring non-reply message.'
         );


### PR DESCRIPTION
## Summary
- mention the user and delete the original message when starting a reply thread
- update tests for thread creation logic
- document deletion behaviour in AGENTS.md

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688a233c2e708326a79ff51efec4037f