### PR TITLE
Rework auto threading logic

### DIFF
--- a/src/services/discord/index.test.ts
+++ b/src/services/discord/index.test.ts
@@ -235,20 +235,6 @@ describe('DiscordService', () => {
       });
     });
 
-    describe('buildHistoryFromMessageChain', () => {
-      it('should build history without the latest message', async () => {
-        const msg = createMockMessage({
-          reference: { messageId: '123' },
-        } as Partial<DiscordMessage>);
-        vi.spyOn(service, 'buildPromptFromMessageChain').mockResolvedValue(
-          'User: hello\nRooivalk: hi\nUser: again'
-        );
-
-        const history = await service.buildHistoryFromMessageChain(msg);
-        expect(history).toBe('User: hello\nRooivalk: hi');
-      });
-    });
-
     describe('setupMentionRegex', () => {
       it('should set up mention regex', () => {
         service.setupMentionRegex();

--- a/src/services/discord/index.ts
+++ b/src/services/discord/index.ts
@@ -396,7 +396,7 @@ class DiscordService {
   public async buildPromptFromMessageThread(
     message: DiscordMessage
   ): Promise<string | null> {
-    if (message.thread !== null) {
+    if (message.thread) {
       const thread = await message.thread.messages.fetch();
       const threadMessages = thread.map((msg) => ({
         author:

--- a/src/services/discord/index.ts
+++ b/src/services/discord/index.ts
@@ -215,14 +215,14 @@ class DiscordService {
 
   public async getMessageChain(
     currentMessage: DiscordMessage
-  ): Promise<{ author: 'user' | 'rooivalk'; content: string }[]> {
-    const messageChain: { author: 'user' | 'rooivalk'; content: string }[] = [];
+  ): Promise<{ author: string | 'rooivalk'; content: string }[]> {
+    const messageChain: { author: string | 'rooivalk'; content: string }[] = [];
     try {
       if (currentMessage.reference && currentMessage.reference.messageId) {
         let referencedMessage = await currentMessage.channel.messages.fetch(
           currentMessage.reference.messageId
         );
-        const tempChain: { author: 'user' | 'rooivalk'; content: string }[] =
+        const tempChain: { author: string | 'rooivalk'; content: string }[] =
           [];
         while (
           referencedMessage &&
@@ -232,7 +232,7 @@ class DiscordService {
             author:
               referencedMessage.author.id === this._discordClient.user?.id
                 ? 'rooivalk'
-                : 'user',
+                : referencedMessage.author.displayName,
             content: referencedMessage.content,
           });
           if (
@@ -261,7 +261,7 @@ class DiscordService {
       author:
         currentMessage.author.id === this._discordClient.user?.id
           ? 'rooivalk'
-          : 'user',
+          : currentMessage.author.displayName,
       content: currentMessage.content,
     });
     return messageChain;
@@ -378,17 +378,14 @@ class DiscordService {
             ...entry,
             content:
               index === messageChain.length - 1 &&
-              entry.author === 'user' &&
+              entry.author !== 'rooivalk' &&
               this._mentionRegex
                 ? entry.content.replace(this._mentionRegex, '').trim()
                 : entry.content,
           }));
 
           return chainWithCleanContent
-            .map(
-              (entry) =>
-                `${entry.author === 'user' ? 'User' : 'Rooivalk'}: ${entry.content}`
-            )
+            .map((entry) => `${entry.author}: ${entry.content}`)
             .join('\n');
         }
       }
@@ -396,19 +393,37 @@ class DiscordService {
     return null;
   }
 
-  public async buildHistoryFromMessageChain(
+  public async buildPromptFromMessageThread(
     message: DiscordMessage
   ): Promise<string | null> {
-    const chain = await this.buildPromptFromMessageChain(message);
-    if (!chain) {
-      return null;
+    if (message.thread !== null) {
+      const thread = await message.thread.messages.fetch();
+      const threadMessages = thread.map((msg) => ({
+        author:
+          msg.author.id === this._discordClient.user?.id
+            ? 'rooivalk'
+            : msg.author.displayName,
+        content: msg.content,
+      }));
+
+      if (threadMessages && threadMessages.length) {
+        const chainWithCleanContent = threadMessages.map((entry, index) => ({
+          ...entry,
+          content:
+            index === threadMessages.length - 1 &&
+            entry.author !== 'rooivalk' &&
+            this._mentionRegex
+              ? entry.content.replace(this._mentionRegex, '').trim()
+              : entry.content,
+        }));
+
+        return chainWithCleanContent
+          .map((entry) => `${entry.author}: ${entry.content}`)
+          .join('\n');
+      }
     }
-    const lines = chain.split('\n');
-    if (lines.length === 0) {
-      return null;
-    }
-    lines.pop();
-    return lines.length > 0 ? lines.join('\n') : null;
+
+    return null;
   }
 
   public setupMentionRegex(): void {

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -48,7 +48,7 @@ class OpenAIService {
     persona: Persona,
     prompt: string,
     emojis: string[] = [],
-    history?: string | null
+    history: string | null = null
   ) {
     try {
       let instructions = this.getInstructions(persona, emojis);

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -48,7 +48,7 @@ const mockDiscordService = vi.mocked({
   getRooivalkResponse: vi.fn().mockReturnValue('Error!'),
   fetchScheduledEventsBetween: vi.fn(),
   buildPromptFromMessageChain: vi.fn(),
-  buildHistoryFromMessageChain: vi.fn(),
+  buildPromptFromMessageThread: vi.fn(),
   registerSlashCommands: vi.fn(),
   sendReadyMessage: vi.fn(),
   setupMentionRegex: vi.fn(),
@@ -94,17 +94,17 @@ describe('Rooivalk', () => {
   });
 
   describe('when processing a message', () => {
-    describe('and buildHistoryFromMessageChain returns history', () => {
+    describe('and buildPromptFromMessageChain returns history', () => {
       it('should pass history to OpenAI if available', async () => {
         const userMessage = createMockMessage({
           content: `<@${BOT_ID}> Hi!`,
         } as Partial<DiscordMessage>);
-        mockDiscordService.buildHistoryFromMessageChain.mockResolvedValue(
+        mockDiscordService.buildPromptFromMessageChain.mockResolvedValue(
           'User: Hi!\nRooivalk: Hello!'
         );
         await (rooivalk as any).processMessage(userMessage);
         expect(
-          mockDiscordService.buildHistoryFromMessageChain
+          mockDiscordService.buildPromptFromMessageChain
         ).toHaveBeenCalledWith(userMessage);
 
         expect(mockOpenAIClient.createResponse).toHaveBeenCalledWith(
@@ -180,12 +180,12 @@ describe('Rooivalk', () => {
       });
     });
 
-    describe('and buildHistoryFromMessageChain returns null', () => {
+    describe('and buildPromptFromMessageChain returns null', () => {
       it('should use message content if no history is available', async () => {
         const userMessage = createMockMessage({
           content: `<@${BOT_ID}> Hello bot!`,
         } as Partial<DiscordMessage>);
-        mockDiscordService.buildHistoryFromMessageChain.mockResolvedValue(null);
+        mockDiscordService.buildPromptFromMessageChain.mockResolvedValue(null);
         await (rooivalk as any).processMessage(userMessage);
 
         expect(mockOpenAIClient.createResponse).toHaveBeenCalledWith(
@@ -202,7 +202,7 @@ describe('Rooivalk', () => {
         const userMessage = createMockMessage({
           content: `<@${BOT_ID}> Fail!`,
         } as Partial<DiscordMessage>);
-        mockDiscordService.buildHistoryFromMessageChain.mockResolvedValue(null);
+        mockDiscordService.buildPromptFromMessageChain.mockResolvedValue(null);
         mockOpenAIClient.createResponse.mockResolvedValue(null);
         await (rooivalk as any).processMessage(userMessage);
         expect(userMessage.reply).toHaveBeenCalledWith('Error!');
@@ -214,7 +214,7 @@ describe('Rooivalk', () => {
         const userMessage = createMockMessage({
           content: `<@${BOT_ID}> Fail!`,
         } as Partial<DiscordMessage>);
-        mockDiscordService.buildHistoryFromMessageChain.mockResolvedValue(null);
+        mockDiscordService.buildPromptFromMessageChain.mockResolvedValue(null);
         mockOpenAIClient.createResponse.mockRejectedValue(
           new Error('OpenAI error!')
         );

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -356,7 +356,9 @@ class Rooivalk {
   public async handleWeatherCommand(
     interaction: ChatInputCommandInteraction
   ): Promise<void> {
-    const city = interaction.options.getString('city');
+    const city = interaction.options.getString('city', true);
+    await interaction.deferReply();
+
     if (city) {
       const weather = await this._yr.getForecastByLocation(city);
       if (weather) {
@@ -386,7 +388,15 @@ class Rooivalk {
         await interaction.editReply({
           content: response,
         });
+      } else {
+        await interaction.editReply({
+          content: this._discord.getRooivalkResponse('error'),
+        });
       }
+    } else {
+      await interaction.editReply({
+        content: this._discord.getRooivalkResponse('error'),
+      });
     }
   }
 


### PR DESCRIPTION
- Remove redundant `buildHistoryFromMessageChain` method from `DiscordService`
- Add `buildPromptFromMessageThread` to retrieve conversation history when in a thread.
- Update conversation history to include the user display name
- Add `handleWeatherCommand` handler