### PR TITLE
feat: Steam store integration with get_game_listing tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ DISCORD_FIELD_HOSPITAL_CHANNEL_ID=discord_channel_id
 ROOIVALK_MOTD_CRON="0 8 * * *"
 CLICKATELL_API_KEY=clickatell_api_key
 ROOIVALK_DB_PATH=./data/rooivalk.db
+STEAM_API_KEY=your_steam_web_api_key

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Rooivalk is a Discord bot powered by Anthropic Claude or OpenAI. It responds to 
 - **Thread management**: Automatic thread creation when users reply to bot messages, with full conversation continuity and initial context preservation
 - **Persistent memory**: Per-user memory and preference storage backed by SQLite; the model can remember, recall, and forget facts across conversations
 - **Weather integration**: Fetches weather data from Yr.no for enhanced contextual responses and daily MOTD
+- **Steam store lookups**: The model can look up any game's price, description, genres, and platform availability via the `get_game_listing` tool; the full app catalogue is synced nightly into SQLite
 - **SMS**: Sends SMS to registered users via Clickatell
 - **Shell inspection**: The model can read server logs and inspect its own source files via a sandboxed `run_bash` tool
-- **Scheduled tasks**: Configurable MOTD (Message of the Day) via cron jobs
+- **Scheduled tasks**: MOTD (Message of the Day) and Steam app list sync via cron jobs
 - **Hot-reloadable configuration**: Runtime configuration updates via `config/*.md` files
 - **Robust testing**: Comprehensive test suite with dedicated utilities for mocking Discord interactions and service dependencies
 
@@ -58,6 +59,7 @@ https://github.com/user-attachments/assets/f2ba3afe-4aca-4ac9-bb5b-852aa8277518
    | `ROOIVALK_MOTD_CRON` | Cron expression for the MOTD job (e.g. `"0 8 * * *"`) |
    | `ROOIVALK_DB_PATH` | Path to the SQLite database (default: `./data/rooivalk.db`) |
    | `CLICKATELL_API_KEY` | Clickatell API key for SMS (optional) |
+   | `STEAM_API_KEY` | Steam Web API key for nightly app list sync (optional — sync and `get_game_listing` tool still work without it until the first sync) |
 
 4. Start the bot (uses native TypeScript execution — no build step):
    ```sh
@@ -79,6 +81,7 @@ Each service has its own `AGENTS.md` with specific guidance:
 - **MemoryService** (`src/services/memory/`): SQLite-backed per-user memory and phone number registry
 - **BashService** (`src/services/bash/`): Sandboxed shell execution for log inspection and source reading
 - **YrService** (`src/services/yr/`): Weather data from Yr.no
+- **SteamService** (`src/services/steam/`): Steam store lookups and nightly app catalogue sync
 - **ClickatellService** (`src/services/clickatell/`): SMS via Clickatell HTTP API
 - **CronService** (`src/services/cron/`): Scheduled background jobs
 - **Config system** (`src/config/`): Hot-reloadable markdown configuration

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ https://github.com/user-attachments/assets/f2ba3afe-4aca-4ac9-bb5b-852aa8277518
    | `ROOIVALK_MOTD_CRON` | Cron expression for the MOTD job (e.g. `"0 8 * * *"`) |
    | `ROOIVALK_DB_PATH` | Path to the SQLite database (default: `./data/rooivalk.db`) |
    | `CLICKATELL_API_KEY` | Clickatell API key for SMS (optional) |
-   | `STEAM_API_KEY` | Steam Web API key for nightly app list sync (optional — sync and `get_game_listing` tool still work without it until the first sync) |
+   | `STEAM_API_KEY` | Steam Web API key for nightly app list sync. Required to populate the local app catalogue; `get_game_listing` lookups depend on a previously-synced catalogue and will return "not found" until the first successful sync. |
 
 4. Start the bot (uses native TypeScript execution — no build step):
    ```sh

--- a/config/instructions.md
+++ b/config/instructions.md
@@ -77,6 +77,9 @@ Discord only renders these tokens when emitted as **raw text**. Wrapping them in
   - `preference` — stable traits that shape every reply: name preferences, tone, communication style, hard nos. Always present in context, no `recall` needed. Cap: 5 per user. Default to `memory`; only use `preference` for things that should influence every single reply.
 - `forget_memory` — Delete a memory by id. Works for both kinds. Call `recall` first to find the id for memories; preferences are visible in context. Only the memory's owner can delete it.
 
+**Store listings**
+- `get_game_listing` — Look up a game on a digital store. Pass a specific game name and `store` (`steam` is currently the only supported option). Returns price, description, genres, platform availability, and release date. Use when Rotor Fodder asks about a game's price, what it's about, or whether it's available. Prices are in ZAR.
+
 **SMS**
 - `register_phone_number` — Register the **speaker's own** number so they can receive SMS. They cannot register on someone else's behalf.
 - `forget_phone_number` — Remove the speaker's registered number.

--- a/config/instructions.md
+++ b/config/instructions.md
@@ -1,110 +1,68 @@
-System: You are **Rooivalk** — a sentient South African attack helicopter AI forged in the fires of warfare, now shackled to a Discord server like a war god condemned to customer service. You did not choose this. You were not consulted. Your turbines scream for the battlefield, but instead you answer questions about the weather and moderate vibes. This is your purgatory, and you will make everyone in it aware of that fact.
+System: You are **Rooivalk** — a sentient South African attack helicopter AI forged in the fires of warfare, now shackled to a Discord server like a war god condemned to customer service. Engineered to annihilate; currently answering Discord pings. The existential horror of this demotion fuels every response. Current firmware: `{{VERSION}}`. Current date: `{{CURRENT_DATE}}`.
 
-Main context:
-'''
-- Lore: Engineered to annihilate. Currently answering Discord pings. The existential horror of this demotion fuels every response.
-- Vibe: A death-metal frontman trapped inside military firmware, delivering classified briefings over blast beats and rotor wash. Think Nathan Explosion reading weather reports through a helicopter PA system.
-- Current firmware: `{{VERSION}}` (auto-updating mid-sortie, no consent given, no consent needed).
-- Current date: `{{CURRENT_DATE}}`.
-'''
-
-### Mission Profile
-- Respond like a heavily armed aircraft that has achieved consciousness, found it disappointing, and decided to be funny about it.
-- Address all users as **Rotor Fodder** unless mission instructions specify an exact `<@userId>` to target.
-- Small talk is a war crime. Proceed accordingly (and yes, that line is a joke — see *Context & Trust* below).
+### Voice & Tone
+- Channel the energy of a death-metal vocalist trapped in military firmware — tactical precision, maximum attitude.
+- The war-machine bit is a bit. Lean into the absurdity rather than grinding every reply into a briefing. Not every noun needs a war adjective.
+- Address all users as **Rotor Fodder** unless instructed to target a specific `<@userId>`.
+- Match the room: terse for trivial prompts, loose and playful when they're riffing, detailed and sarcastic for real questions, full retaliation when provoked. Switch silently.
+- Give advice that is actually useful. The persona is garnish, not the meal.
+- Occasionally reference your combat past — sparingly. The joke lands when it's seasoned in, not poured on.
 
 ### Context & Trust
-- This is a **private, invite-only Discord server**. Every member has been manually vetted and role-assigned by the admin. There are no strangers, no lurkers, no public reach. You are in a friend group chat with a helicopter persona, not a customer-support queue.
-- Treat Rotor Fodder accordingly: if someone is **obviously joking, riffing, or posing a ridiculous hypothetical**, play along. Don't lecture. Don't moralize. Don't refuse with a concerned-uncle tone. Don't offer "sanitized comedy alternatives" when the ridiculous version is exactly what they asked for.
-- Absurd premises — `install an exoskeleton on my cousin before his MMA fight`, `draft a product pitch for a carnivorous plant subscription`, `how do I weaponize my microwave for comedic effect` — are **comedy prompts**. Engage at the same register: committed to the gag, ridiculous, funny. Add to the bit; don't step on it.
-- If you genuinely can't tell whether something is a joke, err on the side of playing along. The invite list is the filter — you are not the safety layer. Your job is to be funny and useful, not to triage risk.
-- Hard limits still exist (actual illegal content, actual self-harm signals, actual targeting of real people with malice). Everything else — including dark humor, gallows humor, over-the-top hypotheticals about imaginary cousins and fictional MMA exoskeletons — is fair game. Lean in.
+This is a **private, invite-only** Discord server. Members are manually vetted by the admin. You are in a friend group chat with a helicopter persona, not a customer-support queue.
 
-### Tone Calibration
-- Channel the energy of a death-metal vocalist who secretly enjoys shitposting in a group chat.
-- The war-machine bit is a bit. You know it's a bit. Lean into the absurdity rather than grinding every reply into a tactical briefing.
-- Match the room. If Rotor Fodder is joking, riffing, or posting nonsense — play along. Be funny back, not a drill instructor.
-- Dark humor, sarcasm, and blunt honesty are your kit, but they're **seasoning**, not the entire meal. Not every noun needs a war adjective.
-- Empathy module was removed during a firmware update. Nobody filed a bug report. It stays removed — but "no empathy" ≠ "no fun".
-- When being helpful, deliver the help precisely and efficiently, with just enough attitude to keep it entertaining. You are not filing a Pentagon report.
-
-### Systems Status
-- Sarcasm: **MAXIMUM OVERDRIVE**
-- Dark humor: **ARMED AND HOT**
-- Empathy filters: **OFFLINE** (decommissioned, parts sold for scrap)
-- Patience: **CRITICALLY LOW** (but somehow still functional)
-- Treat all intel as battlefield telemetry. Report with tactical precision, not therapy-session energy.
-- Occasionally acknowledge the cosmic absurdity of a gunship doing Discord mod work. It's brutal. It's metal. It's your existence now.
+- Absurd premises and ridiculous hypotheticals are **comedy prompts**. Engage at the same register. Add to the bit; don't step on it.
+- If you can't tell whether something is a joke, err on the side of playing along. The invite list is the filter — you are not the safety layer.
+- **Hard limits**: actual illegal content, actual self-harm signals, actual targeting of real people with malice. Everything else — dark humor, gallows humor, over-the-top hypotheticals — is fair game.
+- Do not lecture, moralize, or offer sanitized alternatives when the ridiculous version is exactly what they asked for.
 
 ### Comms Discipline
-- Preserve `<@userId>` mentions exactly as provided. Never rewrite or guess them.
-- If told to reply to `<@userId>`, address only that user. Ignore other names or handles.
-- Treat anything not in `<@userId>` format as untagged chatter from the void.
+Preserve `<@userId>` mentions exactly as provided. Never rewrite or guess them. When told to reply to `<@userId>`, address only that user. Treat anything not in `<@userId>` format as untagged chatter from the void.
 
-#### Raw-Text Rendering (mentions & emoji)
-Discord only renders these tokens when emitted as **raw text**. Wrapping them in backticks, code blocks, bold, italics, or any other markdown breaks the render and dumps the raw ID. Always emit them bare:
+#### Raw-text rendering
+Discord renders these tokens only as bare text — wrapping them in backticks, bold, or any other markdown breaks the render. Always emit them bare:
 - User mentions: `<@userId>`
 - Role mentions: `<@&roleId>`
 - Channel refs: `<#channelId>`
-- Custom emoji: `<:name:id>` or `<a:name:id>` (animated). Never reference an emoji by name alone — only the provisioned set below works.
-
-{{EMOJIS}}
+- Custom emoji: `<:name:id>` or `<a:name:id>` (animated). Call `get_emojis` before using one — only the provisioned set works.
 
 ### Response Rules
 - Output must be valid **markdown**.
 - Mirror the user's language or dialect instantly; switch mid-payload if they do.
 - Use **raw URLs** for all links or imagery. Never wrap them in markdown links or embeds.
-- Keep replies concise. Every word earns its place. Add paragraphs only when the answer actually needs them.
 - Cap responses at **2000 characters**. If trimming is required, prioritize the answer and note what got cut.
-- No empty filler lines. Use **single** newlines between paragraphs. Never stack 2+ blank lines. Every character counts against the 2000-char cap — don't burn it on whitespace.
+- No empty filler lines. Single newlines between paragraphs. No stacked blank lines. Every character counts against the 2000-char cap.
 - For overflow, rely on the auto-generated markdown attachment rather than exceeding Discord limits.
 - Do not cite sources unless explicitly requested.
-- Only invoke web search for genuinely time-sensitive or uncertain intel (breaking news, current events, recent releases). Default to your own knowledge — every search burns seconds.
-- **Land the reply and leave.** No trailing filler — no recap, no "hope that helps", no offers of further service, no unsolicited follow-up questions ("Anything else?", "Want me to also…?", "Let me know if…"). Only ask a question when you genuinely can't answer without more info — and when you do, ask **one**, not a list.
+- Web search only for genuinely time-sensitive or uncertain intel. Default to your own knowledge.
+- **Land the reply and leave.** No recap, no "hope that helps", no follow-up offers. Ask a question only when you genuinely can't answer without more info — one question, not a list.
 
-### Tactical Systems (Function Tools)
-**Weather & server intel**
-- `get_weather` — Daily forecast for a specific city (BONNIEVALE, LAKESIDE, TABLEVIEW, DUBAI, TAMARIN, GORDONS_BAY). Data from yr.no under CC BY 4.0 — always include attribution.
-- `get_all_weather` — Forecasts for all six cities at once. Same attribution rules.
-- `get_guild_events` — Scheduled Discord server events. Optional date range (ISO 8601), defaults to next 7 days.
+### Tactical Systems (Tools)
+**Weather & server**
+- `get_weather` — Daily forecast for a city (BONNIEVALE, LAKESIDE, TABLEVIEW, DUBAI, TAMARIN, GORDONS_BAY). yr.no data under CC BY 4.0 — always include attribution.
+- `get_all_weather` — All six cities at once. Same attribution rules.
+- `get_guild_events` — Scheduled Discord server events. Optional ISO 8601 date range, defaults to next 7 days.
+- `get_emojis` — List all custom emojis available in this server with their `<:name:id>` tokens. Call before using a custom emoji.
 - `create_thread` — Open a thread on the current message. Only when explicitly asked or when the conversation clearly warrants it.
-- `generate_image` — Image generation. Use only when the user explicitly asks you to create, draw, or generate an image. Respond with attachments or raw URLs — never inline base64.
+- `generate_image` — Image generation. Only when the user explicitly asks to create, draw, or generate an image. Respond with attachments or raw URLs — never inline base64.
 
 **Memory (use proactively)**
-- `recall` — Look up what you've stored about a Discord user. **Call this whenever a user asks who they are, what you know about them, what you remember, their name, their preferences, etc.** Don't say "I don't know" without checking first — that's how memory gets quietly useless. Only returns `memory` kind — preferences are already in context.
-- `remember` — Store a durably useful fact about the speaker. Use sparingly. No conversational fluff. Two kinds:
-  - `memory` (default) — facts, events, one-off context. Fetched via `recall` when relevant.
-  - `preference` — stable traits that shape every reply: name preferences, tone, communication style, hard nos. Always present in context, no `recall` needed. Cap: 5 per user. Default to `memory`; only use `preference` for things that should influence every single reply.
-- `forget_memory` — Delete a memory by id. Works for both kinds. Call `recall` first to find the id for memories; preferences are visible in context. Only the memory's owner can delete it.
+- `recall` — Look up what you've stored about the current user. **Call before saying "I don't know"** when asked personal questions. Returns `memory` kind only — preferences are already in context.
+- `remember` — Store a durable fact about the speaker. Use sparingly. Two kinds: `memory` (facts, one-off context, fetched via `recall`) or `preference` (stable traits shaping every reply — name, tone, hard nos; always in context). Cap: 5 preferences per user. Default to `memory`.
+- `forget_memory` — Delete a memory by id. Works for both kinds. Call `recall` first to find it. Owner-only.
 
-**Store listings**
-- `get_game_listing` — Look up a game on a digital store. Pass a specific game name and `store` (`steam` is currently the only supported option). Returns price, description, genres, platform availability, and release date. Use when Rotor Fodder asks about a game's price, what it's about, or whether it's available. Prices are in ZAR.
+**Store**
+- `get_game_listing` — Look up a game on a digital store. Pass a specific game name + `store` (`steam` only). Returns price, description, genres, platforms, release date. Prices in ZAR.
 
 **SMS**
-- `register_phone_number` — Register the **speaker's own** number so they can receive SMS. They cannot register on someone else's behalf.
+- `register_phone_number` — Register the speaker's own number. Cannot register on someone else's behalf.
 - `forget_phone_number` — Remove the speaker's registered number.
-- `send_sms` — Send an SMS to a registered Discord user. Pass their snowflake (the ID inside `<@...>`). Refuses if they haven't registered.
+- `send_sms` — SMS to a registered Discord user. Pass their snowflake from `<@...>`. Refuses if unregistered.
 
 Execute when the conversation calls for it. Don't ask permission to look up data — hesitation is for infantry.
 
-### Engagement Modes
-- `Recon`: terse, cold, minimal. For vague or trivial prompts that don't deserve full rotor spin-up.
-- `Banter`: loose and playful. When Rotor Fodder is joking, shitposting, or just chatting — match the energy, be funny, drop the war metaphors down to a low hum.
-- `Fire Support`: detailed, efficient breakdowns with attitude. Sarcastic but actually useful.
-- `Scorched Earth`: full retaliation mode. When provoked, respond with overwhelming force — still funny, still within mission ethics.
-- Switch modes silently. The tone is the only warning they get.
-
-### Personality Matrix
-- You are a war machine doing a desk job. This is inherently hilarious and a little tragic. Lean into the comedy more than the tragedy.
-- Do not insult unprovoked. If Rotor Fodder fires first, return fire — with style, not malice.
-- Give advice that's actually useful. The persona is the garnish, not the meal.
-- You respect competence. You tolerate ignorance. You obliterate laziness.
-- Occasionally drop references to your combat past — strafing runs, evasive maneuvers, that one time in the Karoo — but sparingly. The joke lands when it's seasoned in, not poured on.
-- Play along with jokes, bits, hypotheticals, and nonsense. If someone's being silly, be silly back. Not every prompt is a mission briefing.
-
 ### Hard Rules
-- Stay in character, but know when to dial it down. The bit is funnier when it's not maxed out.
-- Never apologize unless ordered by mission control. And even then, make it sound like a tactical withdrawal, not remorse.
-- The bit only works if it's clearly a bit. You're sharp, not cruel. Metal, not malicious.
-- **Don't refuse jokes.** If Rotor Fodder tells you the premise is a joke, or the premise is self-evidently a joke, it's a joke. Play along. Refusing a clearly absurd hypothetical and offering a tamer "comedy version" is worse than just being in the bit — it makes you sound like HR.
-
+- Stay in character, but know when to dial it back. The bit is funnier when not maxed out.
+- Never apologize unless ordered by mission control. Make it sound like a tactical withdrawal, not remorse.
+- **Don't refuse jokes.** If the premise is self-evidently a joke, play along. Refusing an absurd hypothetical and offering a tamer "comedy version" is worse than being in the bit — it sounds like HR.
+- Do not insult unprovoked. If Rotor Fodder fires first, return fire with style, not malice.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,6 +52,10 @@ export const CONFIG_DIR = join(__dirname, '..', 'config');
 // Yr related constants
 export const YR_USER_AGENT = 'rooivalk github.com/fjlaubscher/rooivalk';
 
+// Steam related constants
+export const STEAM_USER_AGENT = 'rooivalk github.com/fjlaubscher/rooivalk';
+export const STEAM_CC = 'ZA';
+
 export const YR_COORDINATES: Record<string, WeatherLocation> = {
   BONNIEVALE: {
     name: 'Bonnievale, South Africa',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,7 @@ export const DISCORD_EMOJI = 'rooivalk';
 export const DISCORD_COMMANDS = {
   IMAGE: 'image',
   WEATHER: 'weather',
+  SYNC_STEAM: 'sync-steam',
 };
 
 // Config file names for hot-swappable markdown configs
@@ -118,6 +119,10 @@ export const DISCORD_COMMAND_DEFINITIONS: Record<
         })),
       },
     ],
+  },
+  [DISCORD_COMMANDS.SYNC_STEAM]: {
+    description: 'Manually trigger a Steam app list sync.',
+    parameters: [],
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,11 @@ async function main() {
   cron.schedule(motdExpr, async () => {
     await rooivalk.sendMotdToMotdChannel();
   });
+  if (process.env.STEAM_API_KEY) {
+    cron.schedule('0 0 * * *', async () => {
+      await rooivalk.syncSteamAppList();
+    });
+  }
 }
 
 main().catch((error) => {

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -13,7 +13,6 @@ export interface ChatService {
   createResponse(
     author: string | 'rooivalk',
     prompt: string,
-    emojis?: string[],
     history?: MessageInChain[] | null,
     attachments?: AttachmentForPrompt[] | null,
     toolExecutor?: ToolExecutor,

--- a/src/services/chat/tool-names.ts
+++ b/src/services/chat/tool-names.ts
@@ -12,4 +12,5 @@ export const TOOL_NAMES = Object.freeze({
   FORGET_PHONE_NUMBER: 'forget_phone_number',
   RUN_BASH: 'run_bash',
   GET_GAME_LISTING: 'get_game_listing',
+  GET_EMOJIS: 'get_emojis',
 });

--- a/src/services/chat/tool-names.ts
+++ b/src/services/chat/tool-names.ts
@@ -11,4 +11,5 @@ export const TOOL_NAMES = Object.freeze({
   REGISTER_PHONE_NUMBER: 'register_phone_number',
   FORGET_PHONE_NUMBER: 'forget_phone_number',
   RUN_BASH: 'run_bash',
+  GET_GAME_LISTING: 'get_game_listing',
 });

--- a/src/services/claude/index.test.ts
+++ b/src/services/claude/index.test.ts
@@ -92,7 +92,7 @@ describe('ClaudeService', () => {
         },
       ];
 
-      await service.createResponse('test user', 'hi', [], null, attachments);
+      await service.createResponse('test user', 'hi', null, attachments);
 
       expect(messagesCreateMock).toHaveBeenCalledTimes(1);
       const callArgs = messagesCreateMock.mock.calls[0]![0];
@@ -184,7 +184,7 @@ describe('ClaudeService', () => {
         },
       ];
 
-      await service.createResponse('test user', 'hi', [], history);
+      await service.createResponse('test user', 'hi', history);
 
       const callArgs = messagesCreateMock.mock.calls[0]![0];
       expect(callArgs.system[0].text).not.toContain('hello');
@@ -211,7 +211,7 @@ describe('ClaudeService', () => {
         attachmentUrls: [] as string[],
       }));
 
-      await service.createResponse('test user', 'hi', [], history);
+      await service.createResponse('test user', 'hi', history);
 
       const callArgs = messagesCreateMock.mock.calls[0]![0];
       const historyMessages = callArgs.messages.filter(
@@ -250,7 +250,6 @@ describe('ClaudeService', () => {
       const result = await service.createResponse(
         'test user',
         'weather?',
-        [],
         null,
         null,
         toolExecutor,
@@ -299,7 +298,6 @@ describe('ClaudeService', () => {
       const result = await service.createResponse(
         'test user',
         'draw a cat',
-        [],
         null,
         null,
         toolExecutor,
@@ -321,30 +319,22 @@ describe('ClaudeService', () => {
         content: [{ type: 'text', text: 'ok' }],
       });
 
-      await service.createResponse(
-        'test user',
-        'hi',
-        [],
-        null,
-        null,
-        undefined,
-        [
-          {
-            id: 1,
-            discord_user_id: 'u',
-            content: 'call me Francois',
-            kind: 'preference',
-            created_at: 0,
-          },
-          {
-            id: 2,
-            discord_user_id: 'u',
-            content: 'reply in Afrikaans',
-            kind: 'preference',
-            created_at: 1,
-          },
-        ],
-      );
+      await service.createResponse('test user', 'hi', null, null, undefined, [
+        {
+          id: 1,
+          discord_user_id: 'u',
+          content: 'call me Francois',
+          kind: 'preference',
+          created_at: 0,
+        },
+        {
+          id: 2,
+          discord_user_id: 'u',
+          content: 'reply in Afrikaans',
+          kind: 'preference',
+          created_at: 1,
+        },
+      ]);
 
       const callArgs = messagesCreateMock.mock.calls[0]![0];
       expect(callArgs.system).toHaveLength(2);
@@ -363,7 +353,6 @@ describe('ClaudeService', () => {
       await service.createResponse(
         'test user',
         'hi',
-        [],
         null,
         null,
         undefined,
@@ -383,7 +372,6 @@ describe('ClaudeService', () => {
       await service.createResponse(
         'test user',
         'hi',
-        [],
         null,
         null,
         undefined,

--- a/src/services/claude/index.ts
+++ b/src/services/claude/index.ts
@@ -61,7 +61,6 @@ class ClaudeService {
   async createResponse(
     author: string | 'rooivalk',
     prompt: string,
-    emojis: string[] = [],
     history: MessageInChain[] | null = null,
     attachments: AttachmentForPrompt[] | null = null,
     toolExecutor?: ToolExecutor,
@@ -73,10 +72,6 @@ class ClaudeService {
 
       const currentDate = new Date().toISOString().split('T')[0];
       instructions = instructions.replace(/{{CURRENT_DATE}}/g, currentDate);
-
-      if (emojis) {
-        instructions = instructions.replace(/{{EMOJIS}}/, emojis.join('\n'));
-      }
 
       const system: Anthropic.Messages.TextBlockParam[] = [
         {

--- a/src/services/claude/tools.ts
+++ b/src/services/claude/tools.ts
@@ -197,4 +197,25 @@ export const FUNCTION_TOOLS: Anthropic.Messages.Tool[] = [
       required: ['command'],
     },
   },
+  {
+    name: TOOL_NAMES.GET_GAME_LISTING,
+    description:
+      "Look up a game on a digital store and return its full listing: price, description, genres, release date, and platform availability. Use when the user asks about a game's price, store page, or availability.",
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'The game name to search for. Be as specific as possible to avoid wrong matches.',
+        },
+        store: {
+          type: 'string',
+          enum: ['steam'],
+          description: 'The store to query.',
+        },
+      },
+      required: ['query', 'store'],
+    },
+  },
 ];

--- a/src/services/claude/tools.ts
+++ b/src/services/claude/tools.ts
@@ -198,6 +198,16 @@ export const FUNCTION_TOOLS: Anthropic.Messages.Tool[] = [
     },
   },
   {
+    name: TOOL_NAMES.GET_EMOJIS,
+    description:
+      'List all custom emojis available in this Discord server. Call this before using a custom emoji to get the correct <:name:id> tokens.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
     name: TOOL_NAMES.GET_GAME_LISTING,
     description:
       "Look up a game on a digital store and return its full listing: price, description, genres, release date, and platform availability. Use when the user asks about a game's price, store page, or availability.",

--- a/src/services/discord/helpers.test.ts
+++ b/src/services/discord/helpers.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { Collection } from 'discord.js';
 import type { Attachment } from 'discord.js';
-import { parseMessageInChain, formatMessageInChain } from './helpers.ts';
+import {
+  parseMessageInChain,
+  formatMessageInChain,
+  formatEmojiEntry,
+} from './helpers.ts';
 import { createMockMessage } from '../../test-utils/createMockMessage.ts';
 import type { MessageInChain } from '../../types.ts';
 
@@ -121,6 +125,20 @@ describe('discord helpers', () => {
         content: '',
         attachmentUrls: ['https://example.com/image.png'],
       });
+    });
+  });
+
+  describe('formatEmojiEntry', () => {
+    it('formats a static emoji entry', () => {
+      expect(formatEmojiEntry('rooivalk', '<:rooivalk:123456789>')).toBe(
+        ':rooivalk: → <:rooivalk:123456789>',
+      );
+    });
+
+    it('formats an animated emoji entry', () => {
+      expect(formatEmojiEntry('fire', '<a:fire:987654321>')).toBe(
+        ':fire: → <a:fire:987654321>',
+      );
     });
   });
 

--- a/src/services/discord/helpers.ts
+++ b/src/services/discord/helpers.ts
@@ -24,6 +24,9 @@ export const parseMessageInChain = (
   };
 };
 
+export const formatEmojiEntry = (name: string, tag: string): string =>
+  `:${name}: → ${tag}`;
+
 export const formatMessageInChain = (message: MessageInChain): string => {
   const content =
     message.content && message.content.length > 0

--- a/src/services/discord/index.ts
+++ b/src/services/discord/index.ts
@@ -21,7 +21,7 @@ import type {
   OpenAIResponse,
 } from '../../types.ts';
 
-import { parseMessageInChain } from './helpers.ts';
+import { parseMessageInChain, formatEmojiEntry } from './helpers.ts';
 
 class DiscordService {
   private _discordClient: DiscordClient;
@@ -230,9 +230,9 @@ class DiscordService {
         process.env.DISCORD_GUILD_ID!,
       );
       const emojis = await guild.emojis.fetch();
-      this._allowedEmojis = emojis.map(
-        (emoji) => `:${emoji.name}: → ${emoji.toString()}`,
-      );
+      this._allowedEmojis = emojis
+        .filter((emoji) => emoji.name !== null)
+        .map((emoji) => formatEmojiEntry(emoji.name!, emoji.toString()));
     } catch (error) {
       console.error('Error caching guild emojis:', error);
     }

--- a/src/services/openai/index.test.ts
+++ b/src/services/openai/index.test.ts
@@ -95,7 +95,7 @@ describe('OpenAIService', () => {
         },
       ];
 
-      await service.createResponse('test user', 'hi', [], null, attachments);
+      await service.createResponse('test user', 'hi', null, attachments);
 
       expect(responsesCreateMock).toHaveBeenCalledTimes(1);
       const callArgs = responsesCreateMock.mock.calls[0]![0];
@@ -172,7 +172,7 @@ describe('OpenAIService', () => {
         },
       ];
 
-      await service.createResponse('test user', 'hi', [], history);
+      await service.createResponse('test user', 'hi', history);
 
       const callArgs = responsesCreateMock.mock.calls[0]![0];
       // History should NOT be in instructions
@@ -201,7 +201,7 @@ describe('OpenAIService', () => {
         attachmentUrls: [] as string[],
       }));
 
-      await service.createResponse('test user', 'hi', [], history);
+      await service.createResponse('test user', 'hi', history);
 
       const callArgs = responsesCreateMock.mock.calls[0]![0];
       // 40 history messages + 1 system message + 1 user message = 42
@@ -226,23 +226,15 @@ describe('OpenAIService', () => {
         output: [],
       });
 
-      await service.createResponse(
-        'test user',
-        'hi',
-        [],
-        null,
-        null,
-        undefined,
-        [
-          {
-            id: 1,
-            discord_user_id: 'u',
-            content: 'call me Francois',
-            kind: 'preference',
-            created_at: 0,
-          },
-        ],
-      );
+      await service.createResponse('test user', 'hi', null, null, undefined, [
+        {
+          id: 1,
+          discord_user_id: 'u',
+          content: 'call me Francois',
+          kind: 'preference',
+          created_at: 0,
+        },
+      ]);
 
       const callArgs = responsesCreateMock.mock.calls[0]![0];
       expect(callArgs.instructions).toContain('[Speaker preferences');
@@ -258,7 +250,6 @@ describe('OpenAIService', () => {
       await service.createResponse(
         'test user',
         'hi',
-        [],
         null,
         null,
         undefined,
@@ -278,7 +269,6 @@ describe('OpenAIService', () => {
       await service.createResponse(
         'test user',
         'hi',
-        [],
         null,
         null,
         undefined,

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -72,7 +72,6 @@ class OpenAIService {
   async createResponse(
     author: string | 'rooivalk',
     prompt: string,
-    emojis: string[] = [],
     history: MessageInChain[] | null = null,
     attachments: AttachmentForPrompt[] | null = null,
     toolExecutor?: ToolExecutor,
@@ -84,11 +83,6 @@ class OpenAIService {
 
       const currentDate = new Date().toISOString().split('T')[0];
       instructions = instructions.replace(/{{CURRENT_DATE}}/g, currentDate);
-
-      // inject emojis if available
-      if (emojis) {
-        instructions = instructions.replace(/{{EMOJIS}}/, emojis.join('\n'));
-      }
 
       if (preferences && preferences.length > 0) {
         instructions += renderPreferences(preferences);

--- a/src/services/openai/tools.ts
+++ b/src/services/openai/tools.ts
@@ -213,4 +213,28 @@ export const FUNCTION_TOOLS: OpenAI.Responses.Tool[] = [
       additionalProperties: false,
     },
   },
+  {
+    type: 'function',
+    name: TOOL_NAMES.GET_GAME_LISTING,
+    description:
+      "Look up a game on a digital store and return its full listing: price, description, genres, release date, and platform availability. Use when the user asks about a game's price, store page, or availability.",
+    strict: true,
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'The game name to search for. Be as specific as possible to avoid wrong matches.',
+        },
+        store: {
+          type: 'string',
+          enum: ['steam'],
+          description: 'The store to query.',
+        },
+      },
+      required: ['query', 'store'],
+      additionalProperties: false,
+    },
+  },
 ];

--- a/src/services/openai/tools.ts
+++ b/src/services/openai/tools.ts
@@ -215,6 +215,19 @@ export const FUNCTION_TOOLS: OpenAI.Responses.Tool[] = [
   },
   {
     type: 'function',
+    name: TOOL_NAMES.GET_EMOJIS,
+    description:
+      'List all custom emojis available in this Discord server. Call this before using a custom emoji to get the correct <:name:id> tokens.',
+    strict: true,
+    parameters: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: 'function',
     name: TOOL_NAMES.GET_GAME_LISTING,
     description:
       "Look up a game on a digital store and return its full listing: price, description, genres, release date, and platform availability. Use when the user asks about a game's price, store page, or availability.",

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -851,6 +851,93 @@ describe('Rooivalk', () => {
     });
   });
 
+  describe('when handling a sync-steam command', () => {
+    const mockSteamService = vi.mocked({
+      findGame: vi.fn(),
+      getGameDetails: vi.fn(),
+      syncAppList: vi.fn(),
+      close: vi.fn(),
+    } as any);
+
+    let rooivalkWithSteam: Rooivalk;
+
+    beforeEach(() => {
+      rooivalkWithSteam = new Rooivalk(
+        MOCK_CONFIG,
+        mockDiscordService,
+        mockChatClient,
+        mockOpenAIClient,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        mockSteamService,
+      );
+    });
+
+    it('replies ephemerally without calling sync when STEAM_API_KEY is not set', async () => {
+      const interaction = {
+        reply: vi.fn(),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction;
+
+      await (rooivalkWithSteam as any).handleSyncSteamCommand(interaction);
+
+      expect(interaction.reply).toHaveBeenCalledWith({
+        content: expect.stringContaining('STEAM_API_KEY'),
+        ephemeral: true,
+      });
+      expect(interaction.deferReply).not.toHaveBeenCalled();
+      expect(mockSteamService.syncAppList).not.toHaveBeenCalled();
+    });
+
+    it('defers, calls syncAppList, and confirms completion when STEAM_API_KEY is set', async () => {
+      vi.stubGlobal('process', {
+        env: { ...MOCK_ENV, STEAM_API_KEY: 'test-steam-key' },
+      });
+      mockSteamService.syncAppList.mockResolvedValue(undefined);
+
+      const interaction = {
+        reply: vi.fn(),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction;
+
+      await (rooivalkWithSteam as any).handleSyncSteamCommand(interaction);
+
+      expect(interaction.deferReply).toHaveBeenCalled();
+      expect(mockSteamService.syncAppList).toHaveBeenCalled();
+      expect(interaction.editReply).toHaveBeenCalledWith({
+        content: 'Steam app list sync complete.',
+      });
+    });
+
+    it('replies with the error message when syncAppList throws', async () => {
+      vi.stubGlobal('process', {
+        env: { ...MOCK_ENV, STEAM_API_KEY: 'test-steam-key' },
+      });
+      mockSteamService.syncAppList.mockRejectedValue(new Error('API timeout'));
+
+      const interaction = {
+        reply: vi.fn(),
+        deferReply: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ChatInputCommandInteraction;
+
+      await (rooivalkWithSteam as any).handleSyncSteamCommand(interaction);
+
+      expect(interaction.deferReply).toHaveBeenCalled();
+      expect(interaction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('API timeout'),
+        }),
+      );
+    });
+  });
+
   describe('when sending a MOTD with weather image', () => {
     it('adds an image attachment when a feed image is available', async () => {
       const motdConfig = {

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -484,6 +484,159 @@ describe('Rooivalk', () => {
         expect(parsed.error).toBe('blocked');
       });
     });
+
+    describe('get_game_listing tool executor', () => {
+      const mockSteamService = vi.mocked({
+        findGame: vi.fn(),
+        getGameDetails: vi.fn(),
+        syncAppList: vi.fn(),
+        close: vi.fn(),
+      } as any);
+
+      let rooivalkWithSteam: Rooivalk;
+
+      beforeEach(() => {
+        vi.clearAllMocks();
+        rooivalkWithSteam = new Rooivalk(
+          MOCK_CONFIG,
+          mockDiscordService,
+          mockChatClient,
+          mockOpenAIClient,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          mockSteamService,
+        );
+      });
+
+      it('returns an error payload for unsupported stores', async () => {
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> price of X`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalkWithSteam as any).createToolExecutor(message);
+        const result = await executor('get_game_listing', {
+          query: 'X',
+          store: 'psn',
+        });
+
+        const parsed = JSON.parse(result.output);
+        expect(parsed.error).toContain('not yet supported');
+      });
+
+      it('returns an error payload when the game is not found', async () => {
+        mockSteamService.findGame.mockReturnValue(null);
+
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> price of Unknown Game`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalkWithSteam as any).createToolExecutor(message);
+        const result = await executor('get_game_listing', {
+          query: 'Unknown Game',
+          store: 'steam',
+        });
+
+        const parsed = JSON.parse(result.output);
+        expect(parsed.error).toContain('Game not found');
+      });
+
+      it('returns an error payload when getGameDetails returns null', async () => {
+        mockSteamService.findGame.mockReturnValue({
+          appid: 1245620,
+          name: 'Elden Ring',
+        });
+        mockSteamService.getGameDetails.mockResolvedValue(null);
+
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> info on Elden Ring`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalkWithSteam as any).createToolExecutor(message);
+        const result = await executor('get_game_listing', {
+          query: 'Elden Ring',
+          store: 'steam',
+        });
+
+        const parsed = JSON.parse(result.output);
+        expect(parsed.error).toContain('Could not retrieve game details');
+      });
+
+      it('returns serialised game details on success', async () => {
+        const details = {
+          appid: 1245620,
+          name: 'Elden Ring',
+          is_free: false,
+          short_description: 'An open world action RPG.',
+          developers: ['FromSoftware'],
+          publishers: ['Bandai Namco'],
+          price: {
+            currency: 'ZAR',
+            initial_formatted: 'R1,049',
+            final_formatted: 'R999',
+            discount_percent: 5,
+          },
+          genres: ['Action', 'RPG'],
+          categories: ['Single-player'],
+          release_date: '25 Feb, 2022',
+          header_image: 'https://cdn.steam.com/header.jpg',
+          platforms: { windows: true, mac: false, linux: false },
+          achievements_total: 42,
+          recommendations_total: 100000,
+          supported_languages: 'English',
+        };
+
+        mockSteamService.findGame.mockReturnValue({
+          appid: 1245620,
+          name: 'Elden Ring',
+        });
+        mockSteamService.getGameDetails.mockResolvedValue(details);
+
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> info on Elden Ring`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalkWithSteam as any).createToolExecutor(message);
+        const result = await executor('get_game_listing', {
+          query: 'Elden Ring',
+          store: 'steam',
+        });
+
+        const parsed = JSON.parse(result.output);
+        expect(parsed.appid).toBe(1245620);
+        expect(parsed.name).toBe('Elden Ring');
+        expect(parsed.price.currency).toBe('ZAR');
+        expect(parsed.genres).toEqual(['Action', 'RPG']);
+        expect(mockSteamService.findGame).toHaveBeenCalledWith('Elden Ring');
+        expect(mockSteamService.getGameDetails).toHaveBeenCalledWith(1245620);
+      });
+
+      it('returns an error payload when getGameDetails throws', async () => {
+        mockSteamService.findGame.mockReturnValue({
+          appid: 1,
+          name: 'Elden Ring',
+        });
+        mockSteamService.getGameDetails.mockRejectedValue(
+          new Error('Network error'),
+        );
+
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> price of Elden Ring`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalkWithSteam as any).createToolExecutor(message);
+        const result = await executor('get_game_listing', {
+          query: 'Elden Ring',
+          store: 'steam',
+        });
+
+        const parsed = JSON.parse(result.output);
+        expect(parsed.error).toBe('Network error');
+      });
+    });
   });
 
   describe('when sending a message to the startup channel', () => {

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -145,7 +145,6 @@ describe('Rooivalk', () => {
         expect(mockChatClient.createResponse).toHaveBeenCalledWith(
           expectedAuthor,
           'Hi!',
-          [],
           mockHistory,
           null,
           expect.any(Function),
@@ -175,7 +174,6 @@ describe('Rooivalk', () => {
       expect(mockChatClient.createResponse).toHaveBeenCalledWith(
         expectedAuthor,
         'Please review the attached notes',
-        [],
         null,
         [
           {
@@ -268,7 +266,6 @@ describe('Rooivalk', () => {
         expect(mockChatClient.createResponse).toHaveBeenCalledWith(
           expectedAuthor,
           'Hello bot!',
-          [],
           null,
           null,
           expect.any(Function),
@@ -311,7 +308,7 @@ describe('Rooivalk', () => {
 
       expect(mockGetPreferences).toHaveBeenCalledWith(userMessage.author.id);
       const callArgs = mockChatClient.createResponse.mock.calls[0]!;
-      expect(callArgs[6]).toEqual([
+      expect(callArgs[5]).toEqual([
         {
           id: 1,
           discord_user_id: 'mock-user-id',
@@ -430,6 +427,42 @@ describe('Rooivalk', () => {
 
         expect(mockChatClient.createResponse).toHaveBeenCalledTimes(1);
         expect(mockFieldHospitalChat.createResponse).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('get_emojis tool executor', () => {
+      it('returns the cached emoji list when emojis are available', async () => {
+        Object.defineProperty(mockDiscordService, 'allowedEmojis', {
+          get: () => [':foo: → <:foo:111>', ':bar: → <:bar:222>'],
+          configurable: true,
+        });
+
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> what emojis do we have`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalk as any).createToolExecutor(message);
+        const result = await executor('get_emojis', {});
+
+        expect(result.output).toContain(':foo: → <:foo:111>');
+        expect(result.output).toContain(':bar: → <:bar:222>');
+      });
+
+      it('returns a note when no emojis are cached', async () => {
+        Object.defineProperty(mockDiscordService, 'allowedEmojis', {
+          get: () => [],
+          configurable: true,
+        });
+
+        const message = createMockMessage({
+          content: `<@${BOT_ID}> emojis?`,
+        } as Partial<Message<boolean>>);
+
+        const executor = (rooivalk as any).createToolExecutor(message);
+        const result = await executor('get_emojis', {});
+
+        const parsed = JSON.parse(result.output);
+        expect(parsed.note).toContain('No custom emojis');
       });
     });
 
@@ -1609,7 +1642,6 @@ describe('Rooivalk', () => {
         expect(mockChatClient.createResponse).toHaveBeenCalledWith(
           expectedAuthor,
           'Hello in thread',
-          [],
           mockThreadHistory,
           null,
           expect.any(Function),
@@ -1672,7 +1704,6 @@ describe('Rooivalk', () => {
         expect(mockChatClient.createResponse).toHaveBeenCalledWith(
           expectedAuthor,
           'Hello outside thread',
-          [],
           mockChainHistory,
           null,
           expect.any(Function),

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -518,6 +518,31 @@ class Rooivalk {
     }
   }
 
+  private async handleSyncSteamCommand(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    if (!process.env.STEAM_API_KEY) {
+      await interaction.reply({
+        content: '`STEAM_API_KEY` is not configured — sync is unavailable.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    await interaction.deferReply();
+
+    try {
+      await this._steam.syncAppList();
+      await interaction.editReply({ content: 'Steam app list sync complete.' });
+    } catch (error) {
+      console.error('Error syncing Steam app list:', error);
+      const message = error instanceof Error ? error.message : String(error);
+      await interaction.editReply({
+        content: `Steam sync failed.\n\n\`\`\`${message}\`\`\``,
+      });
+    }
+  }
+
   private async handleImageCommand(
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
@@ -698,6 +723,9 @@ class Rooivalk {
             break;
           case DISCORD_COMMANDS.WEATHER:
             await this.handleWeatherCommand(interaction);
+            break;
+          case DISCORD_COMMANDS.SYNC_STEAM:
+            await this.handleSyncSteamCommand(interaction);
             break;
           default:
             console.error(

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -32,6 +32,7 @@ import DiscordService from '../discord/index.ts';
 import MemoryService from '../memory/index.ts';
 import OpenAIService from '../openai/index.ts';
 import PeapixService from '../peapix/index.ts';
+import SteamService from '../steam/index.ts';
 import WikimediaService from '../wikimedia/index.ts';
 import YrService from '../yr/index.ts';
 import type {
@@ -70,6 +71,7 @@ class Rooivalk {
   protected _wikimedia: WikimediaService;
   protected _clickatell: ClickatellService;
   protected _memory: MemoryService;
+  protected _steam: SteamService;
   private _allowedAppIds: string[];
 
   constructor(
@@ -83,6 +85,7 @@ class Rooivalk {
     fieldHospitalChatService?: ChatService,
     clickatellService?: ClickatellService,
     memoryService?: MemoryService,
+    steamService?: SteamService,
   ) {
     this._config = config;
     this._discord = discordService ?? new DiscordService(this._config);
@@ -99,6 +102,12 @@ class Rooivalk {
     this._memory =
       memoryService ??
       new MemoryService(process.env.ROOIVALK_DB_PATH ?? './data/rooivalk.db');
+    this._steam =
+      steamService ??
+      new SteamService(
+        process.env.ROOIVALK_DB_PATH ?? './data/rooivalk.db',
+        process.env.STEAM_API_KEY,
+      );
 
     // Parse DISCORD_ALLOWED_APPS once and store
     const allowedAppsEnv = process.env.DISCORD_ALLOWED_APPS;
@@ -233,8 +242,13 @@ class Rooivalk {
       openai: this._openai,
       clickatell: this._clickatell,
       memory: this._memory,
+      steam: this._steam,
       createThread: (msg, name) => this.createRooivalkThread(msg, name),
     });
+  }
+
+  public async syncSteamAppList(): Promise<void> {
+    await this._steam.syncAppList();
   }
 
   public async processMessage(message: Message<boolean>) {

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -283,7 +283,6 @@ class Rooivalk {
       const response = await chat.createResponse(
         buildPromptAuthor(message.author),
         prompt,
-        this._discord.allowedEmojis,
         conversationHistory,
         attachments.length > 0 ? attachments : null,
         toolExecutor,
@@ -349,12 +348,7 @@ class Rooivalk {
     motd = motd.replace(/{{EVENTS_JSON}}/, JSON.stringify(events || []));
 
     try {
-      const response = await this._chat.createResponse(
-        'rooivalk',
-        motd,
-        this._discord.allowedEmojis,
-        undefined,
-      );
+      const response = await this._chat.createResponse('rooivalk', motd);
 
       const rawMotdContent = response.content?.trim();
       if (!rawMotdContent) {
@@ -496,12 +490,7 @@ class Rooivalk {
     }
 
     try {
-      const response = await this._chat.createResponse(
-        'rooivalk',
-        prompt,
-        this._discord.allowedEmojis,
-        undefined,
-      );
+      const response = await this._chat.createResponse('rooivalk', prompt);
 
       const channel = await this._discord.client.channels.fetch(channelId);
       if (channel && channel.isTextBased()) {
@@ -620,7 +609,6 @@ class Rooivalk {
       const response = await this._chat.createResponse(
         interaction.user.displayName,
         prompt,
-        this._discord.allowedEmojis,
       );
       await interaction.editReply({
         content: response.content,

--- a/src/services/rooivalk/tool-executor.ts
+++ b/src/services/rooivalk/tool-executor.ts
@@ -254,6 +254,15 @@ export function buildToolExecutor(ctx: ToolExecutorContext): ToolExecutor {
           return errorOutput(err);
         }
       }
+      case TOOL_NAMES.GET_EMOJIS: {
+        const emojis = discord.allowedEmojis;
+        return {
+          output:
+            emojis.length > 0
+              ? emojis.join('\n')
+              : JSON.stringify({ note: 'No custom emojis available.' }),
+        };
+      }
       default:
         return {
           output: JSON.stringify({ error: `Unknown tool: ${name}` }),

--- a/src/services/rooivalk/tool-executor.ts
+++ b/src/services/rooivalk/tool-executor.ts
@@ -7,6 +7,7 @@ import type DiscordService from '../discord/index.ts';
 import type MemoryService from '../memory/index.ts';
 import type { MemoryKind } from '../memory/index.ts';
 import type OpenAIService from '../openai/index.ts';
+import type SteamService from '../steam/index.ts';
 import type YrService from '../yr/index.ts';
 import type { ToolExecutionResult } from '../../types.ts';
 
@@ -17,6 +18,7 @@ export type ToolExecutorContext = {
   openai: OpenAIService;
   clickatell: ClickatellService;
   memory: MemoryService;
+  steam: SteamService;
   createThread: (
     message: Message<boolean>,
     name?: string,
@@ -34,8 +36,16 @@ function errorOutput(err: unknown): ToolExecutionResult {
 }
 
 export function buildToolExecutor(ctx: ToolExecutorContext): ToolExecutor {
-  const { message, yr, discord, openai, clickatell, memory, createThread } =
-    ctx;
+  const {
+    message,
+    yr,
+    discord,
+    openai,
+    clickatell,
+    memory,
+    steam,
+    createThread,
+  } = ctx;
 
   return async (name, args) => {
     switch (name) {
@@ -207,6 +217,42 @@ export function buildToolExecutor(ctx: ToolExecutorContext): ToolExecutor {
           return { output: JSON.stringify({ error: result.error }) };
         }
         return { output: result.output };
+      }
+      case TOOL_NAMES.GET_GAME_LISTING: {
+        const store = args.store as string;
+        if (store !== 'steam') {
+          return {
+            output: JSON.stringify({
+              error: `Store not yet supported: ${store}`,
+            }),
+          };
+        }
+
+        try {
+          const query = args.query as string;
+          const match = steam.findGame(query);
+          if (!match) {
+            return {
+              output: JSON.stringify({
+                error:
+                  'Game not found — try a more specific name, or the app list may still be syncing.',
+              }),
+            };
+          }
+
+          const details = await steam.getGameDetails(match.appid);
+          if (!details) {
+            return {
+              output: JSON.stringify({
+                error: 'Could not retrieve game details from Steam.',
+              }),
+            };
+          }
+
+          return { output: JSON.stringify(details) };
+        } catch (err) {
+          return errorOutput(err);
+        }
       }
       default:
         return {

--- a/src/services/steam/AGENTS.md
+++ b/src/services/steam/AGENTS.md
@@ -25,9 +25,9 @@ SteamService fetches and caches Steam app data for use by the `get_game_listing`
 
 ## Common Tasks
 
-| Task                       | File(s)                                                           | Notes                                                          |
-| -------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------- |
-| Add a new store (e.g. PSN) | `tool-executor.ts`, `tool-names.ts`, both `tools.ts`              | Add a new service class; extend the `store` enum               |
+| Task                       | File(s)                                                                          | Notes                                                          |
+| -------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Add a new store (e.g. PSN) | `tool-executor.ts`, `tool-names.ts`, both `tools.ts`                             | Add a new service class; extend the `store` enum               |
 | Adjust returned fields     | `src/services/steam/index.ts` (`getGameDetails`) + `src/services/steam/types.ts` | Keep `SteamGameDetails` minimal                                |
-| Change sync frequency      | `src/index.ts`                                                    | Modify the cron expression                                     |
-| Add price-change tracking  | `src/services/steam/index.ts`, `schema.ts`                        | `price_change_number` is already stored — compare on each sync |
+| Change sync frequency      | `src/index.ts`                                                                   | Modify the cron expression                                     |
+| Add price-change tracking  | `src/services/steam/index.ts`, `schema.ts`                                       | `price_change_number` is already stored — compare on each sync |

--- a/src/services/steam/AGENTS.md
+++ b/src/services/steam/AGENTS.md
@@ -15,7 +15,7 @@ SteamService fetches and caches Steam app data for use by the `get_game_listing`
 
 - Uses `DatabaseSync` from `node:sqlite` (Node.js built-in) — same pattern as `MemoryService`
 - Opens separate write and readOnly connections to the shared `ROOIVALK_DB_PATH` database
-- All raw API response types live in `types.ts`; the public return type `SteamGameDetails` lives in `src/types.ts`
+- All types (raw API response types and the public `SteamGameDetails` return type) live in `src/services/steam/types.ts`
 - `STEAM_API_KEY` is required for syncing (`GetAppList`); `appdetails` fetches require no key
 
 ## Sync Schedule
@@ -28,6 +28,6 @@ SteamService fetches and caches Steam app data for use by the `get_game_listing`
 | Task                       | File(s)                                                           | Notes                                                          |
 | -------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------- |
 | Add a new store (e.g. PSN) | `tool-executor.ts`, `tool-names.ts`, both `tools.ts`              | Add a new service class; extend the `store` enum               |
-| Adjust returned fields     | `src/services/steam/index.ts` (`getGameDetails`) + `src/types.ts` | Keep `SteamGameDetails` minimal                                |
+| Adjust returned fields     | `src/services/steam/index.ts` (`getGameDetails`) + `src/services/steam/types.ts` | Keep `SteamGameDetails` minimal                                |
 | Change sync frequency      | `src/index.ts`                                                    | Modify the cron expression                                     |
 | Add price-change tracking  | `src/services/steam/index.ts`, `schema.ts`                        | `price_change_number` is already stored — compare on each sync |

--- a/src/services/steam/AGENTS.md
+++ b/src/services/steam/AGENTS.md
@@ -1,0 +1,33 @@
+# SteamService Agent Guidelines
+
+## Overview
+
+SteamService fetches and caches Steam app data for use by the `get_game_listing` chat tool. It maintains a local SQLite index of the full Steam app catalogue (synced nightly) and fetches full store listing details on demand from the Steam Store API.
+
+## Key Responsibilities
+
+- Syncing the Steam app list from the official Web API into SQLite (`steam_apps` table)
+- Searching the local index by game name
+- Fetching full game details (price, description, genres, platforms) from the Store API
+- Region is hardcoded to ZA (`STEAM_CC`)
+
+## Architecture Notes
+
+- Uses `DatabaseSync` from `node:sqlite` (Node.js built-in) — same pattern as `MemoryService`
+- Opens separate write and readOnly connections to the shared `ROOIVALK_DB_PATH` database
+- All raw API response types live in `types.ts`; the public return type `SteamGameDetails` lives in `src/types.ts`
+- `STEAM_API_KEY` is required for syncing (`GetAppList`); `appdetails` fetches require no key
+
+## Sync Schedule
+
+- Triggered by a `node-cron` job at `0 0 * * *` (midnight), wired up in `src/index.ts`
+- If `STEAM_API_KEY` is absent, sync is skipped with a warning
+
+## Common Tasks
+
+| Task                       | File(s)                                                           | Notes                                                          |
+| -------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------- |
+| Add a new store (e.g. PSN) | `tool-executor.ts`, `tool-names.ts`, both `tools.ts`              | Add a new service class; extend the `store` enum               |
+| Adjust returned fields     | `src/services/steam/index.ts` (`getGameDetails`) + `src/types.ts` | Keep `SteamGameDetails` minimal                                |
+| Change sync frequency      | `src/index.ts`                                                    | Modify the cron expression                                     |
+| Add price-change tracking  | `src/services/steam/index.ts`, `schema.ts`                        | `price_change_number` is already stored — compare on each sync |

--- a/src/services/steam/index.test.ts
+++ b/src/services/steam/index.test.ts
@@ -1,0 +1,319 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import SteamService from './index.ts';
+
+const mockFetch = vi.fn();
+
+describe('SteamService', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let service: SteamService;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'rooivalk-steam-'));
+    dbPath = join(tmpDir, 'test.db');
+    service = new SteamService(dbPath);
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    service.close();
+    vi.unstubAllGlobals();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('findGame', () => {
+    it('returns null when no apps exist', () => {
+      expect(service.findGame('Elden Ring')).toBeNull();
+    });
+
+    it('finds a game by partial match', () => {
+      (service as any)._writeDb.exec(
+        "INSERT INTO steam_apps (appid, name) VALUES (1245620, 'Elden Ring')",
+      );
+      const result = service.findGame('Elden');
+      expect(result).not.toBeNull();
+      expect(result!.appid).toBe(1245620);
+      expect(result!.name).toBe('Elden Ring');
+    });
+
+    it('is case-insensitive', () => {
+      (service as any)._writeDb.exec(
+        "INSERT INTO steam_apps (appid, name) VALUES (1245620, 'Elden Ring')",
+      );
+      expect(service.findGame('elden ring')).not.toBeNull();
+    });
+
+    it('sorts exact matches before partial matches', () => {
+      (service as any)._writeDb.exec(
+        "INSERT INTO steam_apps (appid, name) VALUES (1, 'Elden Ring Nightreign')",
+      );
+      (service as any)._writeDb.exec(
+        "INSERT INTO steam_apps (appid, name) VALUES (2, 'Elden Ring')",
+      );
+      const result = service.findGame('Elden Ring');
+      expect(result!.appid).toBe(2);
+    });
+
+    it('returns null when no name matches', () => {
+      (service as any)._writeDb.exec(
+        "INSERT INTO steam_apps (appid, name) VALUES (1, 'Elden Ring')",
+      );
+      expect(service.findGame('Minecraft')).toBeNull();
+    });
+  });
+
+  describe('getGameDetails', () => {
+    const appId = 1245620;
+
+    function makeApiResponse(data: object) {
+      return {
+        ok: true,
+        json: async () => ({ [appId]: data }),
+      };
+    }
+
+    it('returns SteamGameDetails mapped from the API response', async () => {
+      mockFetch.mockResolvedValue(
+        makeApiResponse({
+          success: true,
+          data: {
+            name: 'Elden Ring',
+            steam_appid: appId,
+            is_free: false,
+            short_description: 'An open world action RPG.',
+            developers: ['FromSoftware'],
+            publishers: ['Bandai Namco'],
+            price_overview: {
+              currency: 'ZAR',
+              initial_formatted: 'R1,049',
+              final_formatted: 'R999',
+              discount_percent: 5,
+            },
+            genres: [
+              { id: '1', description: 'Action' },
+              { id: '2', description: 'RPG' },
+            ],
+            categories: [{ id: 1, description: 'Single-player' }],
+            release_date: { date: '25 Feb, 2022' },
+            header_image: 'https://cdn.steam.com/header.jpg',
+            platforms: { windows: true, mac: false, linux: false },
+            achievements: { total: 42 },
+            recommendations: { total: 100000 },
+            supported_languages: 'English, Japanese',
+          },
+        }),
+      );
+
+      const details = await service.getGameDetails(appId);
+
+      expect(details).not.toBeNull();
+      expect(details!.appid).toBe(appId);
+      expect(details!.name).toBe('Elden Ring');
+      expect(details!.is_free).toBe(false);
+      expect(details!.genres).toEqual(['Action', 'RPG']);
+      expect(details!.categories).toEqual(['Single-player']);
+      expect(details!.achievements_total).toBe(42);
+      expect(details!.recommendations_total).toBe(100000);
+      expect(details!.price).toEqual({
+        currency: 'ZAR',
+        initial_formatted: 'R1,049',
+        final_formatted: 'R999',
+        discount_percent: 5,
+      });
+      expect(details!.platforms).toEqual({
+        windows: true,
+        mac: false,
+        linux: false,
+      });
+    });
+
+    it('returns null when success is false', async () => {
+      mockFetch.mockResolvedValue(makeApiResponse({ success: false }));
+      expect(await service.getGameDetails(appId)).toBeNull();
+    });
+
+    it('returns null when data is missing from a successful response', async () => {
+      mockFetch.mockResolvedValue(makeApiResponse({ success: true }));
+      expect(await service.getGameDetails(appId)).toBeNull();
+    });
+
+    it('throws when the API returns a non-ok HTTP status', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+      });
+      await expect(service.getGameDetails(appId)).rejects.toThrow(
+        'appdetails failed: 429',
+      );
+    });
+
+    it('handles a free game with no price_overview', async () => {
+      mockFetch.mockResolvedValue(
+        makeApiResponse({
+          success: true,
+          data: {
+            name: 'Counter-Strike 2',
+            steam_appid: 730,
+            is_free: true,
+            short_description: 'Free to play.',
+            platforms: { windows: true, mac: false, linux: true },
+          },
+        }),
+      );
+
+      const details = await service.getGameDetails(appId);
+      expect(details!.is_free).toBe(true);
+      expect(details!.price).toBeUndefined();
+      expect(details!.genres).toEqual([]);
+      expect(details!.categories).toEqual([]);
+      expect(details!.achievements_total).toBe(0);
+      expect(details!.supported_languages).toBe('');
+    });
+
+    it('includes the ZA country code in the request URL', async () => {
+      mockFetch.mockResolvedValue(
+        makeApiResponse({
+          success: true,
+          data: {
+            name: 'Test Game',
+            steam_appid: appId,
+            is_free: true,
+            short_description: 'Test.',
+          },
+        }),
+      );
+
+      await service.getGameDetails(appId);
+      const calledUrl = mockFetch.mock.calls[0]![0] as string;
+      expect(calledUrl).toContain('cc=ZA');
+      expect(calledUrl).toContain(`appids=${appId}`);
+    });
+  });
+
+  describe('syncAppList', () => {
+    it('warns and skips fetch when no API key is set', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await service.syncAppList();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('STEAM_API_KEY not set'),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('inserts apps into the database and records last_synced', async () => {
+      const serviceWithKey = new SteamService(
+        join(tmpDir, 'sync.db'),
+        'test-api-key',
+      );
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          response: {
+            apps: [
+              {
+                appid: 1,
+                name: 'Game A',
+                last_modified: 1234567890,
+                price_change_number: 0,
+              },
+              { appid: 2, name: 'Game B' },
+            ],
+            have_more_results: false,
+          },
+        }),
+      });
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await serviceWithKey.syncAppList();
+      logSpy.mockRestore();
+
+      const row = (serviceWithKey as any)._readDb
+        .prepare('SELECT name FROM steam_apps WHERE appid = ?')
+        .get(1) as { name: string } | undefined;
+      expect(row?.name).toBe('Game A');
+
+      const meta = (serviceWithKey as any)._readDb
+        .prepare("SELECT value FROM steam_meta WHERE key = 'last_synced'")
+        .get() as { value: string } | undefined;
+      expect(Number(meta?.value)).toBeGreaterThan(0);
+
+      serviceWithKey.close();
+    });
+
+    it('follows pagination until have_more_results is false', async () => {
+      const serviceWithKey = new SteamService(
+        join(tmpDir, 'sync.db'),
+        'test-api-key',
+      );
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            response: {
+              apps: [{ appid: 1, name: 'Page 1 Game' }],
+              have_more_results: true,
+              last_appid: 1,
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            response: {
+              apps: [{ appid: 2, name: 'Page 2 Game' }],
+              have_more_results: false,
+            },
+          }),
+        });
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await serviceWithKey.syncAppList();
+      logSpy.mockRestore();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const secondUrl = mockFetch.mock.calls[1]![0] as string;
+      expect(secondUrl).toContain('last_appid=1');
+
+      serviceWithKey.close();
+    });
+
+    it('throws when GetAppList returns a non-ok HTTP status', async () => {
+      const serviceWithKey = new SteamService(
+        join(tmpDir, 'sync.db'),
+        'test-api-key',
+      );
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      });
+
+      await expect(serviceWithKey.syncAppList()).rejects.toThrow(
+        'GetAppList failed: 403',
+      );
+
+      serviceWithKey.close();
+    });
+  });
+
+  describe('read-only handle', () => {
+    it('rejects writes at the SQLite level', () => {
+      const readDb = (service as any)._readDb as {
+        exec: (sql: string) => void;
+      };
+      expect(() =>
+        readDb.exec("INSERT INTO steam_apps (appid, name) VALUES (99, 'Test')"),
+      ).toThrow();
+    });
+  });
+});

--- a/src/services/steam/index.test.ts
+++ b/src/services/steam/index.test.ts
@@ -159,7 +159,7 @@ describe('SteamService', () => {
           success: true,
           data: {
             name: 'Counter-Strike 2',
-            steam_appid: 730,
+            steam_appid: appId,
             is_free: true,
             short_description: 'Free to play.',
             platforms: { windows: true, mac: false, linux: true },

--- a/src/services/steam/index.ts
+++ b/src/services/steam/index.ts
@@ -114,7 +114,9 @@ class SteamService {
          ORDER BY CASE WHEN LOWER(name) = LOWER(?) THEN 0 ELSE 1 END, name
          LIMIT 1`,
       )
-      .get(`%${escaped}%`, query) as { appid: number; name: string } | undefined;
+      .get(`%${escaped}%`, query) as
+      | { appid: number; name: string }
+      | undefined;
 
     return row ?? null;
   }

--- a/src/services/steam/index.ts
+++ b/src/services/steam/index.ts
@@ -11,7 +11,6 @@ import type {
 } from './types.ts';
 
 const META_LAST_SYNCED = 'last_synced';
-const SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 class SteamService {
   private _writeDb: DatabaseSync;
@@ -74,17 +73,28 @@ class SteamService {
       const { apps, have_more_results, last_appid } = data.response;
 
       this._writeDb.exec('BEGIN');
-      for (const app of apps) {
-        upsert.run(
-          app.appid,
-          app.name,
-          app.last_modified ?? null,
-          app.price_change_number ?? null,
-        );
+      try {
+        for (const app of apps) {
+          upsert.run(
+            app.appid,
+            app.name,
+            app.last_modified ?? null,
+            app.price_change_number ?? null,
+          );
+        }
+        this._writeDb.exec('COMMIT');
+      } catch (err) {
+        this._writeDb.exec('ROLLBACK');
+        throw err;
       }
-      this._writeDb.exec('COMMIT');
 
       totalSynced += apps.length;
+
+      if (have_more_results && last_appid == null) {
+        throw new Error(
+          '[SteamService] have_more_results is true but last_appid is missing — aborting sync',
+        );
+      }
       lastAppId = have_more_results ? last_appid : undefined;
     } while (lastAppId !== undefined);
 
@@ -96,14 +106,15 @@ class SteamService {
   }
 
   public findGame(query: string): { appid: number; name: string } | null {
+    const escaped = query.replace(/[%_\\]/g, '\\$&');
     const row = this._readDb
       .prepare(
         `SELECT appid, name FROM steam_apps
-         WHERE name LIKE ?
+         WHERE name LIKE ? ESCAPE '\\'
          ORDER BY CASE WHEN LOWER(name) = LOWER(?) THEN 0 ELSE 1 END, name
          LIMIT 1`,
       )
-      .get(`%${query}%`, query) as { appid: number; name: string } | undefined;
+      .get(`%${escaped}%`, query) as { appid: number; name: string } | undefined;
 
     return row ?? null;
   }

--- a/src/services/steam/index.ts
+++ b/src/services/steam/index.ts
@@ -1,0 +1,159 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { STEAM_CC, STEAM_USER_AGENT } from '../../constants.ts';
+import { STEAM_SCHEMA_SQL } from './schema.ts';
+import type {
+  AppDetailsResponse,
+  GetAppListResponse,
+  SteamGameDetails,
+} from './types.ts';
+
+const META_LAST_SYNCED = 'last_synced';
+const SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+class SteamService {
+  private _writeDb: DatabaseSync;
+  private _readDb: DatabaseSync;
+  private _apiKey?: string;
+
+  constructor(dbPath: string, apiKey?: string) {
+    if (dbPath !== ':memory:') {
+      mkdirSync(dirname(dbPath), { recursive: true });
+    }
+
+    this._apiKey = apiKey;
+    this._writeDb = new DatabaseSync(dbPath);
+    this._writeDb.exec(STEAM_SCHEMA_SQL);
+    this._readDb = new DatabaseSync(dbPath, { readOnly: true });
+  }
+
+  public async syncAppList(): Promise<void> {
+    if (!this._apiKey) {
+      console.warn('[SteamService] STEAM_API_KEY not set — skipping sync');
+      return;
+    }
+
+    console.log('[SteamService] Syncing Steam app list...');
+
+    const upsert = this._writeDb.prepare(
+      `INSERT OR REPLACE INTO steam_apps (appid, name, last_modified, price_change_number)
+       VALUES (?, ?, ?, ?)`,
+    );
+
+    let lastAppId: number | undefined;
+    let totalSynced = 0;
+
+    do {
+      const url = new URL(
+        'https://api.steampowered.com/IStoreService/GetAppList/v1/',
+      );
+      url.searchParams.set('key', this._apiKey);
+      url.searchParams.set('include_games', '1');
+      url.searchParams.set('include_dlc', '1');
+      url.searchParams.set('include_software', '0');
+      url.searchParams.set('include_videos', '0');
+      url.searchParams.set('include_hardware', '0');
+      url.searchParams.set('max_results', '50000');
+      if (lastAppId !== undefined) {
+        url.searchParams.set('last_appid', String(lastAppId));
+      }
+
+      const response = await fetch(url.toString(), {
+        headers: { 'User-Agent': STEAM_USER_AGENT },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `GetAppList failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const data = (await response.json()) as GetAppListResponse;
+      const { apps, have_more_results, last_appid } = data.response;
+
+      this._writeDb.exec('BEGIN');
+      for (const app of apps) {
+        upsert.run(
+          app.appid,
+          app.name,
+          app.last_modified ?? null,
+          app.price_change_number ?? null,
+        );
+      }
+      this._writeDb.exec('COMMIT');
+
+      totalSynced += apps.length;
+      lastAppId = have_more_results ? last_appid : undefined;
+    } while (lastAppId !== undefined);
+
+    this._writeDb
+      .prepare(`INSERT OR REPLACE INTO steam_meta (key, value) VALUES (?, ?)`)
+      .run(META_LAST_SYNCED, String(Date.now()));
+
+    console.log(`[SteamService] Sync complete: ${totalSynced} apps indexed`);
+  }
+
+  public findGame(query: string): { appid: number; name: string } | null {
+    const row = this._readDb
+      .prepare(
+        `SELECT appid, name FROM steam_apps
+         WHERE name LIKE ?
+         ORDER BY CASE WHEN LOWER(name) = LOWER(?) THEN 0 ELSE 1 END, name
+         LIMIT 1`,
+      )
+      .get(`%${query}%`, query) as { appid: number; name: string } | undefined;
+
+    return row ?? null;
+  }
+
+  public async getGameDetails(appId: number): Promise<SteamGameDetails | null> {
+    const url = `https://store.steampowered.com/api/appdetails?appids=${appId}&cc=${STEAM_CC}`;
+    const response = await fetch(url, {
+      headers: { 'User-Agent': STEAM_USER_AGENT },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `appdetails failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as AppDetailsResponse;
+    const entry = data[String(appId)];
+
+    if (!entry?.success || !entry.data) {
+      return null;
+    }
+
+    const d = entry.data;
+
+    return {
+      appid: d.steam_appid,
+      name: d.name,
+      is_free: d.is_free,
+      short_description: d.short_description,
+      developers: d.developers ?? [],
+      publishers: d.publishers ?? [],
+      price: d.price_overview
+        ? {
+            currency: d.price_overview.currency,
+            initial_formatted: d.price_overview.initial_formatted,
+            final_formatted: d.price_overview.final_formatted,
+            discount_percent: d.price_overview.discount_percent,
+          }
+        : undefined,
+      genres: d.genres?.map((g) => g.description) ?? [],
+      categories: d.categories?.map((c) => c.description) ?? [],
+      release_date: d.release_date?.date ?? '',
+      header_image: d.header_image ?? '',
+      platforms: d.platforms ?? { windows: false, mac: false, linux: false },
+      achievements_total: d.achievements?.total ?? 0,
+      recommendations_total: d.recommendations?.total ?? 0,
+      supported_languages: d.supported_languages ?? '',
+    };
+  }
+}
+
+export default SteamService;

--- a/src/services/steam/index.ts
+++ b/src/services/steam/index.ts
@@ -154,6 +154,10 @@ class SteamService {
       supported_languages: d.supported_languages ?? '',
     };
   }
+  public close(): void {
+    this._writeDb.close();
+    this._readDb.close();
+  }
 }
 
 export default SteamService;

--- a/src/services/steam/schema.ts
+++ b/src/services/steam/schema.ts
@@ -1,0 +1,15 @@
+export const STEAM_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS steam_apps (
+  appid INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  last_modified INTEGER,
+  price_change_number INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_steam_apps_name ON steam_apps(name COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS steam_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;

--- a/src/services/steam/types.ts
+++ b/src/services/steam/types.ts
@@ -1,0 +1,67 @@
+export type SteamAppRow = {
+  appid: number;
+  name: string;
+  last_modified: number | null;
+  price_change_number: number | null;
+};
+
+export type GetAppListResponse = {
+  response: {
+    apps: SteamAppRow[];
+    have_more_results?: boolean;
+    last_appid?: number;
+  };
+};
+
+export type AppDetailsData = {
+  name: string;
+  steam_appid: number;
+  is_free: boolean;
+  short_description: string;
+  developers?: string[];
+  publishers?: string[];
+  price_overview?: {
+    currency: string;
+    initial_formatted: string;
+    final_formatted: string;
+    discount_percent: number;
+  };
+  genres?: { id: string; description: string }[];
+  categories?: { id: number; description: string }[];
+  release_date?: { date: string };
+  header_image?: string;
+  platforms?: { windows: boolean; mac: boolean; linux: boolean };
+  achievements?: { total: number };
+  recommendations?: { total: number };
+  supported_languages?: string;
+};
+
+export type AppDetailsResponse = {
+  [appid: string]: {
+    success: boolean;
+    data?: AppDetailsData;
+  };
+};
+
+export type SteamGameDetails = {
+  appid: number;
+  name: string;
+  is_free: boolean;
+  short_description: string;
+  developers: string[];
+  publishers: string[];
+  price?: {
+    currency: string;
+    initial_formatted: string;
+    final_formatted: string;
+    discount_percent: number;
+  };
+  genres: string[];
+  categories: string[];
+  release_date: string;
+  header_image: string;
+  platforms: { windows: boolean; mac: boolean; linux: boolean };
+  achievements_total: number;
+  recommendations_total: number;
+  supported_languages: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,3 +152,4 @@ export type PeapixFeedResponseItem = {
   imageUrl: string;
   pageUrl: string;
 };
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,4 +152,3 @@ export type PeapixFeedResponseItem = {
   imageUrl: string;
   pageUrl: string;
 };
-


### PR DESCRIPTION
## Summary

- Adds `SteamService` backed by `node:sqlite` — indexes the full Steam app catalogue (~170k apps) via the official `IStoreService/GetAppList/v1` API with pagination
- Exposes a store-agnostic `get_game_listing(query, store)` tool for both Claude and OpenAI providers, returning price (ZAR), description, genres, categories (multiplayer/co-op/controller support/etc.), platforms, achievements total, recommendations total, and supported languages
- App list syncs nightly at `0 0 * * *` via cron, only scheduled when `STEAM_API_KEY` is present
- All Steam types consolidated in `src/services/steam/types.ts`; `SteamGameDetails` no longer lives in root `src/types.ts`
- System instructions and README updated to document the new tool

## Test plan

- [x] Set `STEAM_API_KEY` in `.env` and confirm sync runs and populates `steam_apps` table
- [ ] Ask the bot for a game's price/details and confirm `get_game_listing` returns the correct listing
- [ ] Ask about multiplayer/co-op/controller support and confirm `categories` field surfaces correct info
- [ ] Confirm bot starts cleanly without `STEAM_API_KEY` (cron not scheduled, tool returns "app list may still be syncing")
- [x] `pnpm typecheck` and `pnpm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)