### PR TITLE
feat: AI-generated images for daily MOTD

### DIFF
--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -972,7 +972,63 @@ describe('Rooivalk', () => {
   });
 
   describe('when sending a MOTD with weather image', () => {
-    it('adds an image attachment when a feed image is available', async () => {
+    it('uses AI-generated image when createImage succeeds', async () => {
+      const motdConfig = {
+        ...MOCK_CONFIG,
+        motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
+      };
+      const motdContent = 'Good morning!';
+      const mockChannel = { isTextBased: () => true, send: vi.fn() };
+
+      Object.defineProperty(mockDiscordService, 'motdChannelId', {
+        get: () => 'motd-channel-id',
+        configurable: true,
+      });
+      Object.defineProperty(mockDiscordService, 'client', {
+        get: () => ({
+          user: { id: BOT_ID, tag: 'TestBot#0000' },
+          channels: { fetch: vi.fn().mockResolvedValue(mockChannel) },
+        }),
+        configurable: true,
+      });
+
+      mockDiscordService.getGuildEventsBetween.mockResolvedValue([]);
+      mockOpenAIClient.createResponse.mockResolvedValue({
+        type: 'text',
+        content: motdContent,
+        base64Images: [],
+      });
+      mockDiscordService.buildMessageReply.mockReturnValue({
+        content: motdContent,
+      });
+
+      const fakeBase64 = Buffer.from('fake-image').toString('base64');
+      mockOpenAIClient.createImage.mockResolvedValue(fakeBase64);
+
+      const mockYrService = {
+        getAllForecasts: vi.fn().mockResolvedValue([]),
+      } as any;
+      const motdRooivalk = new Rooivalk(
+        motdConfig,
+        mockDiscordService,
+        mockOpenAIClient,
+        mockYrService,
+        mockPeapixService,
+        mockWikimediaService,
+      );
+
+      await motdRooivalk.sendMotdToMotdChannel();
+
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
+      expect(mockWikimediaService.getCityImage).not.toHaveBeenCalled();
+      expect(mockPeapixService.getImage).not.toHaveBeenCalled();
+
+      const sendPayload = mockChannel.send.mock.calls[0]?.[0];
+      expect(sendPayload?.files).toHaveLength(1);
+      expect(sendPayload?.embeds).toHaveLength(1);
+    });
+
+    it('falls back to Wikimedia when AI generation returns null', async () => {
       const motdConfig = {
         ...MOCK_CONFIG,
         motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
@@ -1042,7 +1098,7 @@ describe('Rooivalk', () => {
 
       await motdRooivalk.sendMotdToMotdChannel();
 
-      expect(mockOpenAIClient.createImage).not.toHaveBeenCalled();
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
       expect(mockDiscordService.buildMessageReply).toHaveBeenCalledWith(
         expect.objectContaining({
           content: motdContent,
@@ -1058,7 +1114,7 @@ describe('Rooivalk', () => {
       expect(sendPayload?.embeds?.[0]?.data?.footer?.text).toBe(
         'Table View Beach',
       );
-      // Should stop after first successful city, not try all
+      // Should stop after first successful Wikimedia city, not try all
       expect(mockWikimediaService.getCityImage).toHaveBeenCalledTimes(1);
       expect(mockPeapixService.getImage).not.toHaveBeenCalled();
     });
@@ -1183,7 +1239,7 @@ describe('Rooivalk', () => {
 
       await motdRooivalk.sendMotdToMotdChannel();
 
-      expect(mockOpenAIClient.createImage).not.toHaveBeenCalled();
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
       // Should try all cities before giving up
       expect(mockWikimediaService.getCityImage).toHaveBeenCalledTimes(
         CITY_COUNT,

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -60,6 +60,39 @@ function shuffleArray<T>(items: T[]): T[] {
 
 const MOTD_IMAGE_ATTACHMENT_NAME = 'rooivalk_motd.jpg';
 
+const MOTD_IMAGE_STYLES = [
+  'watercolour painting',
+  'oil painting',
+  'digital concept art',
+  'pencil sketch',
+  'pop art',
+  'art nouveau illustration',
+  'impressionist painting',
+  'ukiyo-e woodblock print',
+  'pixel art',
+  'retro travel poster',
+  'isometric illustration',
+  'stained glass window design',
+  'vintage postcard',
+  'charcoal drawing',
+  'comic book panel',
+];
+
+const MOTD_CITY_ASPECTS = [
+  'a famous landmark or monument',
+  'the local cuisine and street food',
+  'a hidden gem only locals know about',
+  'the skyline at golden hour',
+  'a bustling local market scene',
+  'the surrounding natural landscape',
+  'a cultural festival or tradition',
+  'the distinctive architecture',
+  'everyday street life',
+  'wildlife native to the region',
+  'the coastline or waterfront',
+  'a historical scene from the past',
+];
+
 class Rooivalk {
   protected _config: InMemoryConfig;
   protected _discord: DiscordService;
@@ -356,7 +389,6 @@ class Rooivalk {
         return;
       }
 
-      // Try Wikimedia city image for each city (in random order), skipping failures; fall back to Peapix if all cities fail
       let motdImage: {
         heading: string;
         attribution: string;
@@ -365,50 +397,73 @@ class Rooivalk {
 
       const locations = Object.values(YR_COORDINATES);
       const shuffled = shuffleArray(locations);
+      const selectedCity = shuffled[0];
 
-      let errorCount = 0;
-      for (const location of shuffled) {
-        try {
-          const cityImage = await this._wikimedia.getCityImage(location);
-          if (cityImage) {
-            motdImage = {
-              heading: cityImage.cityName,
-              attribution: cityImage.title,
-              buffer: cityImage.buffer,
-            };
-            break;
-          }
-        } catch (err) {
-          errorCount++;
-          console.error(
-            `Wikimedia image fetch failed for ${location.name}:`,
-            err,
-          );
+      const style =
+        MOTD_IMAGE_STYLES[Math.floor(Math.random() * MOTD_IMAGE_STYLES.length)];
+      const aspect =
+        MOTD_CITY_ASPECTS[Math.floor(Math.random() * MOTD_CITY_ASPECTS.length)];
+      const imagePrompt = `${style} depicting ${aspect} of ${selectedCity.name}. Vivid, detailed, atmospheric.`;
+
+      try {
+        const base64Image = await this._openai.createImage(imagePrompt);
+        if (base64Image) {
+          motdImage = {
+            heading: selectedCity.name,
+            attribution: imagePrompt,
+            buffer: Buffer.from(base64Image, 'base64'),
+          };
         }
+      } catch (err) {
+        console.error(
+          `AI image generation failed for ${selectedCity.name}:`,
+          err,
+        );
       }
 
       if (!motdImage) {
-        console.warn(
-          `Wikimedia image unavailable for all ${shuffled.length} cities` +
-            ` (${errorCount} threw, ${shuffled.length - errorCount} returned null).` +
-            ` Falling back to Peapix.`,
-        );
-        try {
-          const peapixImage = await this._peapix.getImage();
-          if (peapixImage) {
-            motdImage = {
-              heading: peapixImage.title ?? 'Image of the day',
-              attribution: peapixImage.copyright,
-              buffer: peapixImage.buffer,
-            };
-          } else {
-            console.warn('Peapix fallback returned no image.');
+        let errorCount = 0;
+        for (const location of shuffled) {
+          try {
+            const cityImage = await this._wikimedia.getCityImage(location);
+            if (cityImage) {
+              motdImage = {
+                heading: cityImage.cityName,
+                attribution: cityImage.title,
+                buffer: cityImage.buffer,
+              };
+              break;
+            }
+          } catch (err) {
+            errorCount++;
+            console.error(
+              `Wikimedia image fetch failed for ${location.name}:`,
+              err,
+            );
           }
-        } catch (peapixErr) {
-          console.error(
-            'Peapix fallback image fetch threw an error:',
-            peapixErr,
+        }
+
+        if (!motdImage) {
+          console.warn(
+            `AI generation and Wikimedia both failed. Falling back to Peapix.`,
           );
+          try {
+            const peapixImage = await this._peapix.getImage();
+            if (peapixImage) {
+              motdImage = {
+                heading: peapixImage.title ?? 'Image of the day',
+                attribution: peapixImage.copyright,
+                buffer: peapixImage.buffer,
+              };
+            } else {
+              console.warn('Peapix fallback returned no image.');
+            }
+          } catch (peapixErr) {
+            console.error(
+              'Peapix fallback image fetch threw an error:',
+              peapixErr,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Use OpenAI image generation as the primary MOTD image source instead of Wikimedia photos
- Randomly selects from 15 art styles (watercolour, pixel art, retro travel poster, etc.) and 12 city aspects (landmarks, cuisine, wildlife, etc.) for variety
- Falls back to Wikimedia then Peapix if AI generation fails

## Test plan
- [ ] Verify MOTD sends with AI-generated image by setting `ROOIVALK_MOTD_CRON=*/1 * * * *`
- [ ] Verify fallback to Wikimedia when `createImage` returns null
- [ ] Verify fallback to Peapix when both AI and Wikimedia fail
- [ ] All 116 unit tests pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)