### PR TITLE
feat: AI-generated images for daily MOTD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Other files and directories follow standard Node.js/TypeScript project conventio
 | Add thread-related tests     | `services/rooivalk/index.test.ts`        | Use mock threads with `createMockMessage`   |
 | Update message history       | `services/discord/index.ts`              | Modify `buildMessageChainFrom*` methods; use `setThreadInitialContext()` for thread context preservation |
 | Add test                     | `<service>/index.test.ts`                | Use `test-utils/createMockMessage.ts` and `test-utils/mock.ts` |
-| Update MOTD image feed       | `services/wikimedia/index.ts`, `services/peapix/index.ts` | Wikimedia is primary, Peapix is fallback |
+| Update MOTD image feed       | `services/rooivalk/index.ts`             | AI generation is primary (via `OpenAIService.createImage`), Wikimedia is first fallback, Peapix is last resort. Style/aspect arrays are in `index.ts`. |
 | Update config system         | `src/config/loader.ts`, `config/*.md`    | Modify config loading/watching; update markdown configs |
 | Update config/constants      | `constants.ts`, `.env.example`           | Add new constants or env vars               |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rooivalk is a Discord bot powered by Anthropic Claude or OpenAI. It responds to 
 - **Steam store lookups**: The model can look up any game's price, description, genres, and platform availability via the `get_game_listing` tool; the full app catalogue is synced nightly into SQLite
 - **SMS**: Sends SMS to registered users via Clickatell
 - **Shell inspection**: The model can read server logs and inspect its own source files via a sandboxed `run_bash` tool
-- **Scheduled tasks**: MOTD (Message of the Day) and Steam app list sync via cron jobs
+- **Scheduled tasks**: MOTD (Message of the Day) with AI-generated city artwork in varied art styles, and Steam app list sync via cron jobs
 - **Hot-reloadable configuration**: Runtime configuration updates via `config/*.md` files
 - **Robust testing**: Comprehensive test suite with dedicated utilities for mocking Discord interactions and service dependencies
 

--- a/src/services/rooivalk/AGENTS.md
+++ b/src/services/rooivalk/AGENTS.md
@@ -33,6 +33,21 @@ The RooivalkService contains the core business logic for the bot. It processes m
 - Manages conversation context and history
 - Handles system prompts and instructions
 
+### MOTD Image Generation
+
+The daily MOTD uses a three-tier image fallback strategy:
+
+1. **AI-generated image** (primary): Calls `OpenAIService.createImage()` with a randomly composed prompt combining a style and city aspect for the selected city
+2. **Wikimedia** (fallback): Fetches a geo-located photo via `WikimediaService.getCityImage()`
+3. **Peapix** (last resort): Fetches Bing's image of the day via `PeapixService.getImage()`
+
+Image prompt composition uses two module-level arrays:
+
+- `MOTD_IMAGE_STYLES` — 15 art styles (watercolour, pixel art, retro travel poster, etc.)
+- `MOTD_CITY_ASPECTS` — 12 subject topics (landmarks, cuisine, wildlife, etc.)
+
+A random style + aspect + city name are combined into the prompt each day for variety.
+
 ## Bot Behavior Logic
 
 ### Message Processing Rules
@@ -70,8 +85,11 @@ The RooivalkService contains the core business logic for the bot. It processes m
 ## Integration Points
 
 - **DiscordService**: For Discord API operations and message handling
-- **OpenAIService**: For AI-generated responses
+- **ChatService**: For AI-generated text responses (MOTD, conversations)
+- **OpenAIService**: For image generation (`createImage`)
 - **YrService**: For weather data integration
+- **WikimediaService**: For geo-located city photos (MOTD image fallback)
+- **PeapixService**: For Bing image of the day (MOTD last-resort fallback)
 - **CronService**: For scheduled tasks and operations
 - **Config system**: For hot-swappable configuration
 

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -972,7 +972,64 @@ describe('Rooivalk', () => {
   });
 
   describe('when sending a MOTD with weather image', () => {
-    it('adds an image attachment when a feed image is available', async () => {
+    it('uses AI-generated image when createImage succeeds', async () => {
+      const motdConfig = {
+        ...MOCK_CONFIG,
+        motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
+      };
+      const motdContent = 'Good morning!';
+      const mockChannel = { isTextBased: () => true, send: vi.fn() };
+
+      Object.defineProperty(mockDiscordService, 'motdChannelId', {
+        get: () => 'motd-channel-id',
+        configurable: true,
+      });
+      Object.defineProperty(mockDiscordService, 'client', {
+        get: () => ({
+          user: { id: BOT_ID, tag: 'TestBot#0000' },
+          channels: { fetch: vi.fn().mockResolvedValue(mockChannel) },
+        }),
+        configurable: true,
+      });
+
+      mockDiscordService.getGuildEventsBetween.mockResolvedValue([]);
+      mockChatClient.createResponse.mockResolvedValue({
+        type: 'text',
+        content: motdContent,
+        base64Images: [],
+      });
+      mockDiscordService.buildMessageReply.mockReturnValue({
+        content: motdContent,
+      });
+
+      const fakeBase64 = Buffer.from('fake-image').toString('base64');
+      mockOpenAIClient.createImage.mockResolvedValue(fakeBase64);
+
+      const mockYrService = {
+        getAllForecasts: vi.fn().mockResolvedValue([]),
+      } as any;
+      const motdRooivalk = new Rooivalk(
+        motdConfig,
+        mockDiscordService,
+        mockChatClient,
+        mockOpenAIClient,
+        mockYrService,
+        mockPeapixService,
+        mockWikimediaService,
+      );
+
+      await motdRooivalk.sendMotdToMotdChannel();
+
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
+      expect(mockWikimediaService.getCityImage).not.toHaveBeenCalled();
+      expect(mockPeapixService.getImage).not.toHaveBeenCalled();
+
+      const sendPayload = mockChannel.send.mock.calls[0]?.[0];
+      expect(sendPayload?.files).toHaveLength(1);
+      expect(sendPayload?.embeds).toHaveLength(1);
+    });
+
+    it('falls back to Wikimedia when AI generation returns null', async () => {
       const motdConfig = {
         ...MOCK_CONFIG,
         motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
@@ -1042,7 +1099,7 @@ describe('Rooivalk', () => {
 
       await motdRooivalk.sendMotdToMotdChannel();
 
-      expect(mockOpenAIClient.createImage).not.toHaveBeenCalled();
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
       expect(mockDiscordService.buildMessageReply).toHaveBeenCalledWith(
         expect.objectContaining({
           content: motdContent,
@@ -1058,7 +1115,7 @@ describe('Rooivalk', () => {
       expect(sendPayload?.embeds?.[0]?.data?.footer?.text).toBe(
         'Table View Beach',
       );
-      // Should stop after first successful city, not try all
+      // Should stop after first successful Wikimedia city, not try all
       expect(mockWikimediaService.getCityImage).toHaveBeenCalledTimes(1);
       expect(mockPeapixService.getImage).not.toHaveBeenCalled();
     });
@@ -1183,7 +1240,7 @@ describe('Rooivalk', () => {
 
       await motdRooivalk.sendMotdToMotdChannel();
 
-      expect(mockOpenAIClient.createImage).not.toHaveBeenCalled();
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
       // Should try all cities before giving up
       expect(mockWikimediaService.getCityImage).toHaveBeenCalledTimes(
         CITY_COUNT,

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -60,6 +60,39 @@ function shuffleArray<T>(items: T[]): T[] {
 
 const MOTD_IMAGE_ATTACHMENT_NAME = 'rooivalk_motd.jpg';
 
+const MOTD_IMAGE_STYLES = [
+  'watercolour painting',
+  'oil painting',
+  'digital concept art',
+  'pencil sketch',
+  'pop art',
+  'art nouveau illustration',
+  'impressionist painting',
+  'ukiyo-e woodblock print',
+  'pixel art',
+  'retro travel poster',
+  'isometric illustration',
+  'stained glass window design',
+  'vintage postcard',
+  'charcoal drawing',
+  'comic book panel',
+];
+
+const MOTD_CITY_ASPECTS = [
+  'a famous landmark or monument',
+  'the local cuisine and street food',
+  'a hidden gem only locals know about',
+  'the skyline at golden hour',
+  'a bustling local market scene',
+  'the surrounding natural landscape',
+  'a cultural festival or tradition',
+  'the distinctive architecture',
+  'everyday street life',
+  'wildlife native to the region',
+  'the coastline or waterfront',
+  'a historical scene from the past',
+];
+
 class Rooivalk {
   protected _config: InMemoryConfig;
   protected _discord: DiscordService;
@@ -356,7 +389,6 @@ class Rooivalk {
         return;
       }
 
-      // Try Wikimedia city image for each city (in random order), skipping failures; fall back to Peapix if all cities fail
       let motdImage: {
         heading: string;
         attribution: string;
@@ -365,50 +397,71 @@ class Rooivalk {
 
       const locations = Object.values(YR_COORDINATES);
       const shuffled = shuffleArray(locations);
+      const selectedCity = shuffled[0];
 
-      let errorCount = 0;
-      for (const location of shuffled) {
-        try {
-          const cityImage = await this._wikimedia.getCityImage(location);
-          if (cityImage) {
-            motdImage = {
-              heading: cityImage.cityName,
-              attribution: cityImage.title,
-              buffer: cityImage.buffer,
-            };
-            break;
-          }
-        } catch (err) {
-          errorCount++;
-          console.error(
-            `Wikimedia image fetch failed for ${location.name}:`,
-            err,
-          );
+      const style =
+        MOTD_IMAGE_STYLES[Math.floor(Math.random() * MOTD_IMAGE_STYLES.length)];
+      const aspect =
+        MOTD_CITY_ASPECTS[Math.floor(Math.random() * MOTD_CITY_ASPECTS.length)];
+      const imagePrompt = `${style} depicting ${aspect} of ${selectedCity.name}. Vivid, detailed, atmospheric.`;
+
+      try {
+        const base64Image = await this._openai.createImage(imagePrompt);
+        if (base64Image) {
+          motdImage = {
+            heading: selectedCity.name,
+            attribution: imagePrompt,
+            buffer: Buffer.from(base64Image, 'base64'),
+          };
         }
+      } catch (err) {
+        console.error(
+          `AI image generation failed for ${selectedCity.name}:`,
+          err,
+        );
       }
 
       if (!motdImage) {
-        console.warn(
-          `Wikimedia image unavailable for all ${shuffled.length} cities` +
-            ` (${errorCount} threw, ${shuffled.length - errorCount} returned null).` +
-            ` Falling back to Peapix.`,
-        );
-        try {
-          const peapixImage = await this._peapix.getImage();
-          if (peapixImage) {
-            motdImage = {
-              heading: peapixImage.title ?? 'Image of the day',
-              attribution: peapixImage.copyright,
-              buffer: peapixImage.buffer,
-            };
-          } else {
-            console.warn('Peapix fallback returned no image.');
+        for (const location of shuffled) {
+          try {
+            const cityImage = await this._wikimedia.getCityImage(location);
+            if (cityImage) {
+              motdImage = {
+                heading: cityImage.cityName,
+                attribution: cityImage.title,
+                buffer: cityImage.buffer,
+              };
+              break;
+            }
+          } catch (err) {
+            console.error(
+              `Wikimedia image fetch failed for ${location.name}:`,
+              err,
+            );
           }
-        } catch (peapixErr) {
-          console.error(
-            'Peapix fallback image fetch threw an error:',
-            peapixErr,
+        }
+
+        if (!motdImage) {
+          console.warn(
+            `AI generation and Wikimedia both failed. Falling back to Peapix.`,
           );
+          try {
+            const peapixImage = await this._peapix.getImage();
+            if (peapixImage) {
+              motdImage = {
+                heading: peapixImage.title ?? 'Image of the day',
+                attribution: peapixImage.copyright,
+                buffer: peapixImage.buffer,
+              };
+            } else {
+              console.warn('Peapix fallback returned no image.');
+            }
+          } catch (peapixErr) {
+            console.error(
+              'Peapix fallback image fetch threw an error:',
+              peapixErr,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Use OpenAI image generation as the primary MOTD image source instead of Wikimedia photos
- Randomly selects from 15 art styles (watercolour, pixel art, retro travel poster, etc.) and 12 city aspects (landmarks, cuisine, wildlife, etc.) for variety
- Falls back to Wikimedia then Peapix if AI generation fails

## Test plan
- [ ] Verify MOTD sends with AI-generated image by setting `ROOIVALK_MOTD_CRON=*/1 * * * *`
- [ ] Verify fallback to Wikimedia when `createImage` returns null
- [ ] Verify fallback to Peapix when both AI and Wikimedia fail
- [ ] All unit tests pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)