### PR TITLE
feat: flesh out emoji leaderboard with embed, links, and pings

### DIFF
--- a/src/services/emoji/AGENTS.md
+++ b/src/services/emoji/AGENTS.md
@@ -7,9 +7,9 @@ EmojiService records Discord reaction events and provides the three aggregation 
 ## Key Responsibilities
 
 - Inserting one row per `MessageReactionAdd` event that passes all filter rules
-- Querying top receivers (whose messages got the most reactions) for a time window
-- Querying top givers (who handed out the most reactions) for a time window
-- Querying per-emoji champions (top reactor per emoji by usage) for a time window
+- `getTopMessages` — individual messages that received the most reactions in a time window, with the author and channel/message IDs needed to build a jump link
+- `getTopGivers` — users who handed out the most reactions in a time window, each with their single most-used (favourite) emoji
+- `getTopEmojis` — the most-used emojis server-wide in a time window, by total reaction count
 
 ## Architecture Notes
 

--- a/src/services/emoji/index.test.ts
+++ b/src/services/emoji/index.test.ts
@@ -32,65 +32,58 @@ describe('EmojiService', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  describe('getTopReceivers', () => {
-    it('returns the receiver after a reaction is recorded', () => {
+  describe('getTopMessages', () => {
+    it('returns the message after a reaction is recorded', () => {
       emoji.recordReaction(BASE);
       const now = Date.now();
-      const rows = emoji.getTopReceivers(
+      const rows = emoji.getTopMessages(
         'guild-1',
         now - 60_000,
         now + 60_000,
         5,
       );
       expect(rows).toHaveLength(1);
-      expect(rows[0]!.user_id).toBe('author-1');
+      expect(rows[0]!.message_id).toBe('msg-1');
+      expect(rows[0]!.channel_id).toBe('channel-1');
+      expect(rows[0]!.message_author_id).toBe('author-1');
       expect(rows[0]!.count).toBe(1);
     });
 
-    it('aggregates multiple reactions to the same author', () => {
+    it('aggregates multiple reactions on the same message', () => {
       emoji.recordReaction(BASE);
       emoji.recordReaction({ ...BASE, reactorId: 'reactor-2' });
       const now = Date.now();
-      const rows = emoji.getTopReceivers(
+      const rows = emoji.getTopMessages(
         'guild-1',
         now - 60_000,
         now + 60_000,
         5,
       );
+      expect(rows).toHaveLength(1);
       expect(rows[0]!.count).toBe(2);
     });
 
-    it('sorts by count descending', () => {
-      emoji.recordReaction({
-        ...BASE,
-        messageAuthorId: 'author-a',
-        reactorId: 'r1',
-      });
-      emoji.recordReaction({
-        ...BASE,
-        messageAuthorId: 'author-b',
-        reactorId: 'r2',
-      });
-      emoji.recordReaction({
-        ...BASE,
-        messageAuthorId: 'author-b',
-        reactorId: 'r3',
-      });
+    it('ranks individual messages, not authors', () => {
+      // Same author, two messages: each message stays its own row.
+      emoji.recordReaction({ ...BASE, messageId: 'msg-a', reactorId: 'r1' });
+      emoji.recordReaction({ ...BASE, messageId: 'msg-b', reactorId: 'r2' });
+      emoji.recordReaction({ ...BASE, messageId: 'msg-b', reactorId: 'r3' });
       const now = Date.now();
-      const rows = emoji.getTopReceivers(
+      const rows = emoji.getTopMessages(
         'guild-1',
         now - 60_000,
         now + 60_000,
         5,
       );
-      expect(rows[0]!.user_id).toBe('author-b');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]!.message_id).toBe('msg-b');
       expect(rows[0]!.count).toBe(2);
     });
 
     it('excludes reactions outside the window', () => {
       emoji.recordReaction(BASE);
       const past = Date.now() - 200_000;
-      const rows = emoji.getTopReceivers(
+      const rows = emoji.getTopMessages(
         'guild-1',
         past - 60_000,
         past - 1_000,
@@ -103,12 +96,12 @@ describe('EmojiService', () => {
       for (let i = 0; i < 10; i++) {
         emoji.recordReaction({
           ...BASE,
-          messageAuthorId: `author-${i}`,
+          messageId: `msg-${i}`,
           reactorId: `r-${i}`,
         });
       }
       const now = Date.now();
-      const rows = emoji.getTopReceivers(
+      const rows = emoji.getTopMessages(
         'guild-1',
         now - 60_000,
         now + 60_000,
@@ -119,29 +112,41 @@ describe('EmojiService', () => {
   });
 
   describe('getTopGivers', () => {
-    it('returns the reactor after a reaction is recorded', () => {
+    it('returns the reactor with their favourite emoji', () => {
       emoji.recordReaction(BASE);
       const now = Date.now();
       const rows = emoji.getTopGivers('guild-1', now - 60_000, now + 60_000, 5);
       expect(rows[0]!.user_id).toBe('reactor-1');
       expect(rows[0]!.count).toBe(1);
+      expect(rows[0]!.fav_emoji_name).toBe('🔥');
+      expect(rows[0]!.fav_emoji_id).toBeNull();
+    });
+
+    it('picks the most-used emoji as the favourite', () => {
+      emoji.recordReaction({ ...BASE, emojiName: '🔥', messageId: 'm1' });
+      emoji.recordReaction({ ...BASE, emojiName: '🔥', messageId: 'm2' });
+      emoji.recordReaction({ ...BASE, emojiName: '😀', messageId: 'm3' });
+      const now = Date.now();
+      const rows = emoji.getTopGivers('guild-1', now - 60_000, now + 60_000, 5);
+      expect(rows[0]!.count).toBe(3);
+      expect(rows[0]!.fav_emoji_name).toBe('🔥');
     });
 
     it('sorts by count descending', () => {
       emoji.recordReaction({
         ...BASE,
         reactorId: 'reactor-a',
-        messageAuthorId: 'a1',
+        messageId: 'a1',
       });
       emoji.recordReaction({
         ...BASE,
         reactorId: 'reactor-b',
-        messageAuthorId: 'a2',
+        messageId: 'a2',
       });
       emoji.recordReaction({
         ...BASE,
         reactorId: 'reactor-b',
-        messageAuthorId: 'a3',
+        messageId: 'a3',
       });
       const now = Date.now();
       const rows = emoji.getTopGivers('guild-1', now - 60_000, now + 60_000, 5);
@@ -162,31 +167,15 @@ describe('EmojiService', () => {
     });
   });
 
-  describe('getEmojiChampions', () => {
-    it('picks the top user per emoji', () => {
+  describe('getTopEmojis', () => {
+    it('totals reactions per emoji across all users', () => {
       emoji.recordReaction({ ...BASE, emojiName: '🔥', reactorId: 'r1' });
-      emoji.recordReaction({
-        ...BASE,
-        emojiName: '🔥',
-        reactorId: 'r1',
-        messageAuthorId: 'a2',
-      });
-      emoji.recordReaction({
-        ...BASE,
-        emojiName: '🔥',
-        reactorId: 'r2',
-        messageAuthorId: 'a3',
-      });
+      emoji.recordReaction({ ...BASE, emojiName: '🔥', reactorId: 'r2' });
+      emoji.recordReaction({ ...BASE, emojiName: '😀', reactorId: 'r3' });
       const now = Date.now();
-      const rows = emoji.getEmojiChampions(
-        'guild-1',
-        now - 60_000,
-        now + 60_000,
-        5,
-      );
-      expect(rows).toHaveLength(1);
+      const rows = emoji.getTopEmojis('guild-1', now - 60_000, now + 60_000, 5);
+      expect(rows).toHaveLength(2);
       expect(rows[0]!.emoji_name).toBe('🔥');
-      expect(rows[0]!.user_id).toBe('r1');
       expect(rows[0]!.count).toBe(2);
     });
 
@@ -198,38 +187,27 @@ describe('EmojiService', () => {
         emojiAnimated: false,
       });
       const now = Date.now();
-      const rows = emoji.getEmojiChampions(
-        'guild-1',
-        now - 60_000,
-        now + 60_000,
-        5,
-      );
+      const rows = emoji.getTopEmojis('guild-1', now - 60_000, now + 60_000, 5);
       expect(rows[0]!.emoji_id).toBe('123456');
       expect(rows[0]!.emoji_name).toBe('rooivalk');
     });
 
-    it('respects the emoji limit', () => {
+    it('respects the limit', () => {
       for (let i = 0; i < 10; i++) {
-        emoji.recordReaction({ ...BASE, emojiName: `emoji-${i}` });
+        emoji.recordReaction({
+          ...BASE,
+          emojiName: `emoji-${i}`,
+          messageId: `m-${i}`,
+        });
       }
       const now = Date.now();
-      const rows = emoji.getEmojiChampions(
-        'guild-1',
-        now - 60_000,
-        now + 60_000,
-        3,
-      );
+      const rows = emoji.getTopEmojis('guild-1', now - 60_000, now + 60_000, 3);
       expect(rows.length).toBeLessThanOrEqual(3);
     });
 
     it('returns empty when no reactions exist', () => {
       const now = Date.now();
-      const rows = emoji.getEmojiChampions(
-        'guild-1',
-        now - 60_000,
-        now + 60_000,
-        5,
-      );
+      const rows = emoji.getTopEmojis('guild-1', now - 60_000, now + 60_000, 5);
       expect(rows).toHaveLength(0);
     });
   });

--- a/src/services/emoji/index.ts
+++ b/src/services/emoji/index.ts
@@ -3,7 +3,12 @@ import { dirname } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import { EMOJI_SCHEMA_SQL } from './schema.ts';
-import type { EmojiChampion, RecordReactionParams, TopUser } from './types.ts';
+import type {
+  RecordReactionParams,
+  TopEmoji,
+  TopGiver,
+  TopMessage,
+} from './types.ts';
 
 class EmojiService {
   private _writeDb: DatabaseSync;
@@ -39,22 +44,22 @@ class EmojiService {
       );
   }
 
-  public getTopReceivers(
+  public getTopMessages(
     guildId: string,
     windowStart: number,
     windowEnd: number,
     limit: number,
-  ): TopUser[] {
+  ): TopMessage[] {
     return this._readDb
       .prepare(
-        `SELECT message_author_id AS user_id, COUNT(*) AS count
+        `SELECT message_id, channel_id, message_author_id, COUNT(*) AS count
          FROM emoji_reactions
          WHERE guild_id = ? AND created_at >= ? AND created_at < ?
-         GROUP BY message_author_id
+         GROUP BY message_id, channel_id, message_author_id
          ORDER BY count DESC
          LIMIT ?`,
       )
-      .all(guildId, windowStart, windowEnd, limit) as TopUser[];
+      .all(guildId, windowStart, windowEnd, limit) as TopMessage[];
   }
 
   public getTopGivers(
@@ -62,62 +67,62 @@ class EmojiService {
     windowStart: number,
     windowEnd: number,
     limit: number,
-  ): TopUser[] {
+  ): TopGiver[] {
     return this._readDb
       .prepare(
-        `SELECT reactor_id AS user_id, COUNT(*) AS count
-         FROM emoji_reactions
-         WHERE guild_id = ? AND created_at >= ? AND created_at < ?
-         GROUP BY reactor_id
-         ORDER BY count DESC
-         LIMIT ?`,
-      )
-      .all(guildId, windowStart, windowEnd, limit) as TopUser[];
-  }
-
-  public getEmojiChampions(
-    guildId: string,
-    windowStart: number,
-    windowEnd: number,
-    emojiLimit: number,
-  ): EmojiChampion[] {
-    return this._readDb
-      .prepare(
-        `WITH emoji_totals AS (
-           SELECT emoji_id, emoji_name, emoji_animated, SUM(1) AS total
+        `WITH givers AS (
+           SELECT reactor_id, COUNT(*) AS count
            FROM emoji_reactions
            WHERE guild_id = ? AND created_at >= ? AND created_at < ?
-           GROUP BY emoji_id, emoji_name, emoji_animated
-           ORDER BY total DESC
+           GROUP BY reactor_id
+           ORDER BY count DESC
            LIMIT ?
          ),
-         per_user AS (
-           SELECT r.emoji_id, r.emoji_name, r.emoji_animated, r.reactor_id AS user_id, COUNT(*) AS count
-           FROM emoji_reactions r
-           INNER JOIN emoji_totals t
-             ON r.emoji_id IS t.emoji_id
-             AND r.emoji_name = t.emoji_name
-             AND r.emoji_animated = t.emoji_animated
-           WHERE r.guild_id = ? AND r.created_at >= ? AND r.created_at < ?
-           GROUP BY r.emoji_id, r.emoji_name, r.emoji_animated, r.reactor_id
-         ),
-         ranked AS (
-           SELECT *, ROW_NUMBER() OVER (PARTITION BY emoji_id, emoji_name, emoji_animated ORDER BY count DESC) AS rn
-           FROM per_user
+         fav AS (
+           SELECT reactor_id, emoji_id, emoji_name, emoji_animated,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY reactor_id ORDER BY COUNT(*) DESC
+                  ) AS rn
+           FROM emoji_reactions
+           WHERE guild_id = ? AND created_at >= ? AND created_at < ?
+           GROUP BY reactor_id, emoji_id, emoji_name, emoji_animated
          )
-         SELECT emoji_id, emoji_name, emoji_animated, user_id, count
-         FROM ranked
-         WHERE rn = 1`,
+         SELECT g.reactor_id AS user_id,
+                g.count,
+                f.emoji_id AS fav_emoji_id,
+                f.emoji_name AS fav_emoji_name,
+                f.emoji_animated AS fav_emoji_animated
+         FROM givers g
+         INNER JOIN fav f ON f.reactor_id = g.reactor_id AND f.rn = 1
+         ORDER BY g.count DESC`,
       )
       .all(
         guildId,
         windowStart,
         windowEnd,
-        emojiLimit,
+        limit,
         guildId,
         windowStart,
         windowEnd,
-      ) as EmojiChampion[];
+      ) as TopGiver[];
+  }
+
+  public getTopEmojis(
+    guildId: string,
+    windowStart: number,
+    windowEnd: number,
+    limit: number,
+  ): TopEmoji[] {
+    return this._readDb
+      .prepare(
+        `SELECT emoji_id, emoji_name, emoji_animated, COUNT(*) AS count
+         FROM emoji_reactions
+         WHERE guild_id = ? AND created_at >= ? AND created_at < ?
+         GROUP BY emoji_id, emoji_name, emoji_animated
+         ORDER BY count DESC
+         LIMIT ?`,
+      )
+      .all(guildId, windowStart, windowEnd, limit) as TopEmoji[];
   }
 
   public close(): void {

--- a/src/services/emoji/index.ts
+++ b/src/services/emoji/index.ts
@@ -85,6 +85,7 @@ class EmojiService {
                   ) AS rn
            FROM emoji_reactions
            WHERE guild_id = ? AND created_at >= ? AND created_at < ?
+             AND reactor_id IN (SELECT reactor_id FROM givers)
            GROUP BY reactor_id, emoji_id, emoji_name, emoji_animated
          )
          SELECT g.reactor_id AS user_id,

--- a/src/services/emoji/types.ts
+++ b/src/services/emoji/types.ts
@@ -9,15 +9,24 @@ export type RecordReactionParams = {
   emojiAnimated: boolean;
 };
 
-export type TopUser = {
-  user_id: string;
+export type TopMessage = {
+  message_id: string;
+  channel_id: string;
+  message_author_id: string;
   count: number;
 };
 
-export type EmojiChampion = {
+export type TopGiver = {
+  user_id: string;
+  count: number;
+  fav_emoji_id: string | null;
+  fav_emoji_name: string;
+  fav_emoji_animated: number;
+};
+
+export type TopEmoji = {
   emoji_id: string | null;
   emoji_name: string;
   emoji_animated: number;
-  user_id: string;
   count: number;
 };

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -92,9 +92,9 @@ const mockPeapixService = vi.mocked({
 
 const mockEmojiService = vi.mocked({
   recordReaction: vi.fn(),
-  getTopReceivers: vi.fn().mockReturnValue([]),
+  getTopMessages: vi.fn().mockReturnValue([]),
   getTopGivers: vi.fn().mockReturnValue([]),
-  getEmojiChampions: vi.fn().mockReturnValue([]),
+  getTopEmojis: vi.fn().mockReturnValue([]),
   close: vi.fn(),
 } as any);
 

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -1310,6 +1310,137 @@ describe('Rooivalk', () => {
     });
   });
 
+  describe('sendLeaderboardToMotdChannel', () => {
+    let mockChannel: {
+      isTextBased: () => boolean;
+      send: ReturnType<typeof vi.fn>;
+    };
+
+    const findField = (payload: any, name: string) =>
+      payload?.embeds?.[0]?.data?.fields?.find((f: any) => f.name === name);
+
+    beforeEach(() => {
+      mockChannel = { isTextBased: () => true, send: vi.fn() };
+
+      Object.defineProperty(mockDiscordService, 'motdChannelId', {
+        get: () => 'motd-channel-id',
+        configurable: true,
+      });
+      Object.defineProperty(mockDiscordService, 'client', {
+        get: () => ({
+          user: { id: BOT_ID, tag: 'TestBot#0000' },
+          channels: { fetch: vi.fn().mockResolvedValue(mockChannel) },
+        }),
+        configurable: true,
+      });
+
+      mockEmojiService.getTopMessages.mockReturnValue([]);
+      mockEmojiService.getTopGivers.mockReturnValue([]);
+      mockEmojiService.getTopEmojis.mockReturnValue([]);
+    });
+
+    const buildRooivalk = () =>
+      new Rooivalk(
+        MOCK_CONFIG,
+        mockDiscordService,
+        mockChatClient,
+        mockOpenAIClient,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        mockEmojiService,
+      );
+
+    it('renders an embed with all three sections and a message jump link', async () => {
+      mockEmojiService.getTopMessages.mockReturnValue([
+        {
+          message_id: 'm1',
+          channel_id: 'c1',
+          message_author_id: 'author-1',
+          count: 11,
+        },
+      ]);
+      mockEmojiService.getTopGivers.mockReturnValue([
+        {
+          user_id: 'giver-1',
+          count: 24,
+          fav_emoji_id: null,
+          fav_emoji_name: '🔥',
+          fav_emoji_animated: 0,
+        },
+      ]);
+      mockEmojiService.getTopEmojis.mockReturnValue([
+        { emoji_id: null, emoji_name: '❤️', emoji_animated: 0, count: 23 },
+      ]);
+
+      await buildRooivalk().sendLeaderboardToMotdChannel();
+
+      const payload = mockChannel.send.mock.calls[0]?.[0];
+      expect(payload?.embeds).toHaveLength(1);
+      expect(payload?.embeds?.[0]?.data?.title).toContain('Weekly Emoji Recap');
+
+      const messages = findField(payload, 'Most-loved messages');
+      expect(messages?.value).toContain('<@author-1>');
+      expect(messages?.value).toContain(
+        'https://discord.com/channels/test-guild-id/c1/m1',
+      );
+
+      const reactive = findField(payload, 'Most reactive');
+      expect(reactive?.value).toContain('<@giver-1>');
+      expect(reactive?.value).toContain('🔥');
+
+      const emojis = findField(payload, 'Top emojis');
+      expect(emojis?.value).toContain('❤️');
+      expect(emojis?.value).toContain('23');
+    });
+
+    it('pings every featured user exactly once via content and allowedMentions', async () => {
+      // A user who is both a top author and a top giver should appear once.
+      mockEmojiService.getTopMessages.mockReturnValue([
+        {
+          message_id: 'm1',
+          channel_id: 'c1',
+          message_author_id: 'dup',
+          count: 5,
+        },
+      ]);
+      mockEmojiService.getTopGivers.mockReturnValue([
+        {
+          user_id: 'dup',
+          count: 5,
+          fav_emoji_id: null,
+          fav_emoji_name: '🔥',
+          fav_emoji_animated: 0,
+        },
+        {
+          user_id: 'giver-2',
+          count: 3,
+          fav_emoji_id: null,
+          fav_emoji_name: '😀',
+          fav_emoji_animated: 0,
+        },
+      ]);
+
+      await buildRooivalk().sendLeaderboardToMotdChannel();
+
+      const payload = mockChannel.send.mock.calls[0]?.[0];
+      expect(payload?.content).toContain('<@dup>');
+      expect(payload?.content).toContain('<@giver-2>');
+      expect(payload?.allowedMentions).toEqual({ users: ['dup', 'giver-2'] });
+    });
+
+    it('sends an empty-state message that pings no one when there is no data', async () => {
+      await buildRooivalk().sendLeaderboardToMotdChannel();
+
+      const payload = mockChannel.send.mock.calls[0]?.[0];
+      expect(payload?.embeds).toBeUndefined();
+      expect(MOCK_CONFIG.leaderboardEmptyMessages).toContain(payload?.content);
+      expect(payload?.allowedMentions).toEqual({ users: [] });
+    });
+  });
+
   describe('when initialized', () => {
     it('should set up event handlers and call login', async () => {
       // Patch the once method to immediately call the callback for ClientReady

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -62,6 +62,25 @@ function shuffleArray<T>(items: T[]): T[] {
 
 const MOTD_IMAGE_ATTACHMENT_NAME = 'rooivalk_motd.jpg';
 
+const LEADERBOARD_EMBED_COLOR = 0xe74c3c;
+const LEADERBOARD_MEDALS = ['🥇', '🥈', '🥉'];
+
+const leaderboardRank = (index: number): string =>
+  LEADERBOARD_MEDALS[index] ?? `\`${index + 1}.\``;
+
+const formatReactionEmoji = (
+  emojiId: string | null,
+  emojiName: string,
+  emojiAnimated: number,
+): string =>
+  emojiId
+    ? formatEmoji({
+        id: emojiId,
+        animated: emojiAnimated === 1,
+        name: emojiName,
+      })
+    : emojiName;
+
 const MOTD_IMAGE_STYLES = [
   'watercolour painting',
   'oil painting',
@@ -604,7 +623,7 @@ class Rooivalk {
     const guildId = process.env.DISCORD_GUILD_ID!;
 
     try {
-      const receivers = this._emoji.getTopReceivers(
+      const messages = this._emoji.getTopMessages(
         guildId,
         windowStart,
         now,
@@ -616,7 +635,7 @@ class Rooivalk {
         now,
         LEADERBOARD_LIMIT,
       );
-      const champions = this._emoji.getEmojiChampions(
+      const emojis = this._emoji.getTopEmojis(
         guildId,
         windowStart,
         now,
@@ -633,7 +652,7 @@ class Rooivalk {
         return;
       }
 
-      if (!receivers.length && !givers.length && !champions.length) {
+      if (!messages.length && !givers.length && !emojis.length) {
         const msgs = this._config.leaderboardEmptyMessages;
         const msg =
           msgs.length > 0
@@ -646,64 +665,77 @@ class Rooivalk {
         return;
       }
 
-      const guild = await this._discord.client.guilds.fetch(
-        process.env.DISCORD_GUILD_ID!,
-      );
-      const uniqueIds = new Set([
-        ...receivers.map((r) => r.user_id),
-        ...givers.map((g) => g.user_id),
-        ...champions.map((c) => c.user_id),
-      ]);
-      const nameMap = new Map<string, string>();
-      for (const id of uniqueIds) {
-        try {
-          const member = await guild.members.fetch(id);
-          nameMap.set(id, member.displayName);
-        } catch {
-          nameMap.set(id, userMention(id));
-        }
-      }
-      const displayName = (id: string) => nameMap.get(id) ?? userMention(id);
+      const embed = new EmbedBuilder({
+        title: '🏆 Weekly Emoji Recap',
+        description: 'Reactions from the last 7 days',
+        color: LEADERBOARD_EMBED_COLOR,
+      });
 
-      const lines: string[] = ['**Weekly Emoji Recap** — last 7 days', ''];
-
-      if (receivers.length) {
-        lines.push('**Most-loved messages**');
-        receivers.forEach((r, i) => {
-          lines.push(
-            `${i + 1}. ${displayName(r.user_id)} — ${r.count} reaction${r.count === 1 ? '' : 's'}`,
-          );
+      if (messages.length) {
+        embed.addFields({
+          name: 'Most-loved messages',
+          value: messages
+            .map((m, i) => {
+              const link = `https://discord.com/channels/${guildId}/${m.channel_id}/${m.message_id}`;
+              const plural = m.count === 1 ? '' : 's';
+              return `${leaderboardRank(i)} ${userMention(m.message_author_id)} — [${m.count} reaction${plural}](${link})`;
+            })
+            .join('\n'),
         });
-        lines.push('');
       }
 
       if (givers.length) {
-        lines.push('**Most reactive**');
-        givers.forEach((g, i) => {
-          lines.push(
-            `${i + 1}. ${displayName(g.user_id)} — ${g.count} reaction${g.count === 1 ? '' : 's'} given`,
-          );
+        embed.addFields({
+          name: 'Most reactive',
+          value: givers
+            .map((g, i) => {
+              const plural = g.count === 1 ? '' : 's';
+              const fav = formatReactionEmoji(
+                g.fav_emoji_id,
+                g.fav_emoji_name,
+                g.fav_emoji_animated,
+              );
+              return `${leaderboardRank(i)} ${userMention(g.user_id)} — ${g.count} reaction${plural} given — ${fav} is their favourite`;
+            })
+            .join('\n'),
         });
-        lines.push('');
       }
 
-      if (champions.length) {
-        lines.push('**Emoji champions**');
-        champions.forEach((c) => {
-          const emojiStr = c.emoji_id
-            ? formatEmoji({
-                id: c.emoji_id,
-                animated: c.emoji_animated === 1,
-                name: c.emoji_name,
-              })
-            : c.emoji_name;
-          lines.push(`${emojiStr} — ${displayName(c.user_id)} (${c.count})`);
+      if (emojis.length) {
+        embed.addFields({
+          name: 'Top emojis',
+          value: emojis
+            .map((e, i) => {
+              const emojiStr = formatReactionEmoji(
+                e.emoji_id,
+                e.emoji_name,
+                e.emoji_animated,
+              );
+              const plural = e.count === 1 ? '' : 's';
+              return `${leaderboardRank(i)} ${emojiStr} — ${e.count} use${plural}`;
+            })
+            .join('\n'),
         });
       }
+
+      // Mentions inside an embed never notify — to actually ping the
+      // featured users they must appear in the message content, and the
+      // same IDs must be whitelisted in allowedMentions.
+      const featuredIds = [
+        ...new Set([
+          ...messages.map((m) => m.message_author_id),
+          ...givers.map((g) => g.user_id),
+        ]),
+      ];
 
       await (channel as SendableChannels).send({
-        content: lines.join('\n').trim(),
-        allowedMentions: { users: [] },
+        content: featuredIds.length
+          ? `🏆 This week's emoji recap — take a bow ${featuredIds
+              .map((id) => userMention(id))
+              .join(' ')}`
+          : undefined,
+        embeds: [embed],
+        allowedMentions: { users: featuredIds },
       });
     } catch (err) {
       console.error('[Rooivalk] Error sending leaderboard:', err);


### PR DESCRIPTION
## Description

Fleshes out the barebones weekly emoji leaderboard. The old recap was a plain-text wall of `@name — N reactions` lines; this turns it into a structured, coloured Discord embed and sharpens what each section actually reports.

**EmojiService queries**
- `getTopReceivers` → `getTopMessages`: ranks **individual messages** (not authors) and returns the channel/message IDs needed to build a jump link.
- `getTopGivers`: still ranks the biggest reactors, but now also surfaces each giver's single most-used (favourite) emoji in one query.
- `getEmojiChampions` → `getTopEmojis`: most-used emojis **server-wide** by total count, replacing the gnarly per-reactor "champion" window query.

**Leaderboard rendering (`sendLeaderboardToMotdChannel`)**
- Single coloured `EmbedBuilder` with three fields and 🥇🥈🥉 medal ranks.
- **Most-loved messages**: `🥇 @author — [11 reactions](jump-link)`
- **Most reactive**: `🥇 @giver — 24 reactions given — 🔥 is their favourite`
- **Top emojis**: `🥇 ❤️ — 23 uses`
- Featured users are now **pinged**: their mentions go in the message `content` (mentions inside an embed never notify) and the same IDs are whitelisted in `allowedMentions`. The empty-state "ghost town" message still pings no one.

The 7-day window and top-5 limit remain inline constants.

## How to test
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (emoji + rooivalk suites updated for the new query shapes)
- [ ] `pnpm prettier:check` passes
- [ ] Manually: against a test guild, set `ROOIVALK_LEADERBOARD_CRON="* * * * *"`, add reactions across a few messages/users, and confirm the embed renders with all three sections and that the featured users get pinged
