### PR TITLE
ci: grant Claude review the tools it needs to post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -39,6 +39,12 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # The action only allows read-only tools by default; the code-review
+          # plugin needs the inline-comment MCP tool and gh commands to fetch the
+          # diff and post findings, and Opus is the stronger reviewer.
+          claude_args: |
+            --model claude-opus-4-8
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Description
The Claude Code Review action runs but never posts anything. On PR #79 it ran ~7 min, completed successfully (`subtype: success`, 20 turns), yet posted no inline comments, no review, and no summary.

Root cause: `anthropics/claude-code-action@v1` allows only read-only tools by default. The `code-review` plugin needs the `mcp__github_inline_comment__create_inline_comment` MCP tool to post line-level comments, plus `gh` commands to read the diff and post the summary. With empty `claude_args`, every one of those calls was denied — the run logged `permission_denials_count: 10` and the post-step reported `No buffered inline comments`.

This grants those tools via `claude_args` (matching the official `pr-review-comprehensive.yml` example), and while here:
- switches the reviewer to **Opus** (`--model claude-opus-4-8`) — the prior run used the action's Sonnet default (`claude-sonnet-4-6`); Opus is the stronger reviewer for subtle bugs and cross-file reasoning;
- bumps `actions/checkout` to `v5` (the run warned that v4 runs on the deprecated Node 20).

Independent of #79 (different files), so it can merge in either order.

## How to test
- [ ] Merge and open/update a PR; confirm the `Claude Code Review` job posts inline comments (or a "no issues found" summary) instead of finishing silently
- [ ] In that run's log, confirm `permission_denials_count` is 0 and the model is `claude-opus-4-8`
- [ ] Confirm the `actions/checkout` Node 20 deprecation warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
