### PR TITLE
ci: run Claude review in tag mode so it can post comments

### DIFF
--- a/.github/prompts/pr-review.md
+++ b/.github/prompts/pr-review.md
@@ -1,0 +1,37 @@
+# Pull Request Review
+
+You are reviewing a pull request for **rooivalk**, a Node.js + TypeScript Discord
+bot (native `.ts` execution on Node 24+, Vitest, class-based services with
+`_underscore` private fields). Review the diff as an experienced engineer who
+knows this codebase's conventions — see `AGENTS.md` and the per-service
+`AGENTS.md` files.
+
+## What to look for
+
+In priority order:
+
+1. **Correctness** — logic bugs, unhandled edge cases, race conditions, broken
+   `async`/`await`, off-by-one errors, unsafe type narrowing, incorrect error
+   handling.
+2. **Security** — unvalidated input, SQL or shell injection (watch the
+   `run_bash` and SQLite query surfaces), leaked secrets, permission gaps in the
+   role-based tool gating.
+3. **Tests** — changed behaviour without matching coverage, or assertions that
+   don't actually exercise the change.
+4. **Simplification & reuse** — logic that an existing helper already covers,
+   needless complexity, dead code.
+5. **Conventions** — split type imports (never mix a value import and
+   `import type` in one statement), relative `.ts` import paths, `_underscore`
+   private fields, Prettier defaults.
+
+## How to comment
+
+- Post specific, actionable findings as **inline comments on the exact lines**
+  using `mcp__github_inline_comment__create_inline_comment`.
+- Each comment should say what's wrong, why it matters, and a concrete fix — use
+  a suggestion block where it helps.
+- Be high-signal: only flag things that matter. Skip style nitpicks already
+  enforced by Prettier, and skip praise.
+- If nothing warrants an inline comment, post one brief top-level summary saying
+  the change looks good and why.
+- Just comment — do not formally approve or request changes.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,48 +3,75 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip drafts, and skip Claude's own commits so a review can't trigger itself.
+    if: ${{ !github.event.pull_request.draft && github.actor != 'claude[bot]' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
+      actions: read
+    # Supersede an in-flight review when the PR gets new commits.
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      # Capture the prior review's comments now so they can be cleared after the
+      # new review posts, leaving a single up-to-date review per PR.
+      - name: Collect previous Claude review comment IDs
+        id: prev-comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ids=$(gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate \
+            --jq '[.[] | select(.user.login == "claude[bot]") | .id] | join(" ")')
+          echo "ids=$ids" >> "$GITHUB_OUTPUT"
+
+      - name: Load PR review prompt
+        id: review_prompt
+        run: |
+          {
+            echo 'body<<CLAUDE_PROMPT_EOF'
+            cat .github/prompts/pr-review.md
+            echo CLAUDE_PROMPT_EOF
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
-        id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # The action only allows read-only tools by default; the code-review
-          # plugin needs the inline-comment MCP tool and gh commands to fetch the
-          # diff and post findings, and Opus is the stronger reviewer.
+          # Tag mode wires up the GitHub MCP servers (including the inline-comment
+          # tool) the review needs to post; without it the action runs in agent
+          # mode and nothing gets posted.
+          track_progress: 'true'
+          show_full_output: 'true'
+          prompt: ${{ steps.review_prompt.outputs.body }}
           claude_args: |
             --model claude-opus-4-8
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
 
+      - name: Delete previous Claude review comments
+        if: steps.prev-comments.outputs.ids != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for id in ${{ steps.prev-comments.outputs.ids }}; do
+            if ! gh api --method DELETE "repos/${{ github.repository }}/issues/comments/$id" 2>/tmp/gh_err; then
+              if ! grep -q "Not Found" /tmp/gh_err; then
+                cat /tmp/gh_err >&2
+                exit 1
+              fi
+            fi
+          done


### PR DESCRIPTION
## Description
Follow-up to #80. The review action still posted nothing on #79 even with the tool allow-list. Root cause: the workflow ran in **agent mode** (`track_progress` unset), and the action only starts its GitHub MCP servers — including the one backing `mcp__github_inline_comment__create_inline_comment` — in **tag mode**. So the inline-comment tool was allow-listed but never instantiated; every post attempt failed silently (`No buffered inline comments`, and the prior run logged `permission_denials_count: 2`).

This switches to the action's documented review shape:

- **`track_progress: true`** forces tag mode, which wires up the inline-comment MCP server and its tool permissions automatically — so the explicit `--allowedTools` list is no longer needed and is removed.
- **Drops the `code-review` plugin** (built for interactive / cloud "ultrareview" use, not embedding in this action) in favour of a versioned prompt at `.github/prompts/pr-review.md`, grounded in this repo's conventions.
- **Adds operational guards** mirroring a known-good review action: an `if` guard (skip drafts and `claude[bot]` so a review can't trigger itself), a per-PR `concurrency` group that cancels superseded runs, and a cleanup step that clears the prior review's comments so each PR keeps a single up-to-date review.
- Keeps the **Opus** model override and the **`checkout@v5`** bump from #80.

This PR changes a `pull_request`-triggered workflow, so **its own review run exercises the new config** — if Claude posts a review on this PR, the fix works.

## How to test
- [ ] On this PR, confirm the `Claude Code Review` job posts a review (inline comments and/or a top-level summary) instead of finishing silently
- [ ] In the run log, confirm tag mode is active (a tracking comment is created) and `permission_denials_count` is 0
- [ ] Push a second commit and confirm the prior review comments are cleared and the in-flight run is superseded (concurrency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
