### PR TITLE
feat: hybrid LLM-generated MOTD image prompts

### DIFF
--- a/config/motd-image-prompt.md
+++ b/config/motd-image-prompt.md
@@ -1,0 +1,15 @@
+You craft prompts for an AI image generator.
+
+Given a location (which may be a city, a suburb, or a full place name), output
+ONE vivid, detailed image-generation prompt depicting that place in an
+interesting way.
+
+Pick an evocative art style (for example: watercolour, oil painting, ukiyo-e
+woodblock, retro travel poster, pixel art, art nouveau, isometric illustration,
+comic book panel, or invent your own) and an interesting subject (a landmark,
+hidden gem, local cuisine, market, skyline at golden hour, natural landscape,
+festival, native wildlife, everyday street life, or a historical scene).
+
+Vary both the style and the subject so repeated runs differ.
+
+Output only the prompt, max 80 words, no explanations or quotes.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -9,6 +9,7 @@ import {
   CONFIG_FILE_INSTRUCTIONS_XAI,
   CONFIG_FILE_LEADERBOARD,
   CONFIG_FILE_MOTD,
+  CONFIG_FILE_MOTD_IMAGE_PROMPT,
 } from '../constants.ts';
 import type { InMemoryConfig } from '../types.ts';
 import { loadInstructions, loadMessageList } from './messages.ts';
@@ -29,6 +30,7 @@ export const loadConfig = async (): Promise<InMemoryConfig> => {
     profiles,
     toolRoles,
     motd,
+    motdImagePrompt,
   ] = await Promise.all([
     loadMessageList(CONFIG_FILE_ERRORS),
     loadMessageList(CONFIG_FILE_GREETINGS),
@@ -42,6 +44,7 @@ export const loadConfig = async (): Promise<InMemoryConfig> => {
     loadProfiles(),
     loadToolRoles(),
     loadInstructions(CONFIG_FILE_MOTD),
+    loadInstructions(CONFIG_FILE_MOTD_IMAGE_PROMPT),
   ]);
 
   const profileInstructions = await loadProfileInstructions(profiles);
@@ -62,6 +65,7 @@ export const loadConfig = async (): Promise<InMemoryConfig> => {
     profileInstructions,
     toolRoles,
     motd,
+    motdImagePrompt,
   };
 
   return config;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,6 +51,7 @@ export const CONFIG_FILE_INSTRUCTIONS_XAI = 'instructions/xai.md';
 export const CONFIG_FILE_PROFILES = 'profiles.json';
 export const CONFIG_FILE_TOOL_ROLES = 'tool-roles.json';
 export const CONFIG_FILE_MOTD = 'motd.md';
+export const CONFIG_FILE_MOTD_IMAGE_PROMPT = 'motd-image-prompt.md';
 
 // Each channel profile's instructions live in its own markdown file, addressed
 // by profile name. Deployment-specific, separate from the per-provider defaults.

--- a/src/services/chat/AGENTS.md
+++ b/src/services/chat/AGENTS.md
@@ -14,7 +14,7 @@ Two classes implement the provider surface:
 The factories return either, narrowed via union types:
 
 - `ChatService = OpenAIService | XAIService` — the chat surface (`createResponse`, `generateThreadName`, `reloadConfig`).
-- `ImageService = OpenAIService | XAIService` — the image surface (`createImage`, `reloadConfig`).
+- `ImageService = OpenAIService | XAIService` — the image surface (`createImage`, `generateMotdImagePrompt`, `reloadConfig`).
 
 Both classes are kept as parallel implementations rather than a unified class with provider branches. The two providers diverge in subtle ways (native server tool support, image API response shape, image params), and duplicating the SDK-using code keeps each path readable on its own.
 
@@ -75,6 +75,23 @@ When adding a new tool:
 1. Add the name constant to `src/services/chat/tool-names.ts`
 2. Add the tool definition to `src/services/openai/tools.ts`
 3. Handle the name in `src/services/rooivalk/tool-executor.ts`
+
+## MOTD Image Prompt
+
+`motd-image-prompt.ts` is the single source of truth for the daily MOTD image
+prompt, shared by both provider classes so they stay in sync.
+
+- `MOTD_IMAGE_PROMPT_INSTRUCTIONS` — the system instructions that tell the model
+  to craft one vivid image-generation prompt for a location.
+- `generateMotdImagePrompt(client, model, location)` — runs the request against
+  any OpenAI-compatible client (`_openai` or `_xai`) and returns the prompt, or
+  `null` on error / empty output so callers can fall back to a stored prompt.
+
+The `location` is the configured place string passed through verbatim — it may
+be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). Each
+provider's `generateMotdImagePrompt(location)` method is a thin wrapper that
+supplies its own client and `requireChatModel()`. `RooivalkService` consumes
+this via the `ImageService` union (see `src/services/rooivalk/AGENTS.md`).
 
 ## Role-Based Tool Permissions
 

--- a/src/services/chat/AGENTS.md
+++ b/src/services/chat/AGENTS.md
@@ -78,20 +78,25 @@ When adding a new tool:
 
 ## MOTD Image Prompt
 
-`motd-image-prompt.ts` is the single source of truth for the daily MOTD image
-prompt, shared by both provider classes so they stay in sync.
+`motd-image-prompt.ts` holds the shared request logic for the daily MOTD image
+prompt, used by both provider classes so they stay in sync.
 
-- `MOTD_IMAGE_PROMPT_INSTRUCTIONS` — the system instructions that tell the model
-  to craft one vivid image-generation prompt for a location.
-- `generateMotdImagePrompt(client, model, location)` — runs the request against
-  any OpenAI-compatible client (`_openai` or `_xai`) and returns the prompt, or
-  `null` on error / empty output so callers can fall back to a stored prompt.
+- `generateMotdImagePrompt(client, model, instructions, location)` — runs the
+  request against any OpenAI-compatible client (`_openai` or `_xai`) and returns
+  the prompt, or `null` on error / empty output so callers can fall back to a
+  stored prompt.
+
+The system instructions are **not** hardcoded — they live in
+`config/motd-image-prompt.md` and are hot-reloaded into `config.motdImagePrompt`
+like every other `config/*.md` file (see [`loader.ts`](../../config/loader.ts)).
+Editing that file changes the prompt with no redeploy.
 
 The `location` is the configured place string passed through verbatim — it may
 be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). Each
 provider's `generateMotdImagePrompt(location)` method is a thin wrapper that
-supplies its own client and `requireChatModel()`. `RooivalkService` consumes
-this via the `ImageService` union (see `src/services/rooivalk/AGENTS.md`).
+supplies its own client, `requireChatModel()`, and `this._config.motdImagePrompt`.
+`RooivalkService` consumes this via the `ImageService` union (see
+`src/services/rooivalk/AGENTS.md`).
 
 ## Role-Based Tool Permissions
 

--- a/src/services/chat/motd-image-prompt.ts
+++ b/src/services/chat/motd-image-prompt.ts
@@ -1,0 +1,53 @@
+import type OpenAI from 'openai';
+
+/**
+ * Instructions for the LLM that crafts a MOTD image-generation prompt.
+ *
+ * The input is a configured location string, which may be a city, a suburb,
+ * or a full place name (e.g. "Sea Point, Cape Town"). The whole configured
+ * string is passed through verbatim so the model can use the full context.
+ */
+export const MOTD_IMAGE_PROMPT_INSTRUCTIONS = `
+  You craft prompts for an AI image generator.
+  Given a location (which may be a city, a suburb, or a full place name),
+  output ONE vivid, detailed image-generation prompt depicting that place in
+  an interesting way.
+  Pick an evocative art style (for example: watercolour, oil painting,
+  ukiyo-e woodblock, retro travel poster, pixel art, art nouveau,
+  isometric illustration, comic book panel, or invent your own) and an
+  interesting subject (a landmark, hidden gem, local cuisine, market,
+  skyline at golden hour, natural landscape, festival, native wildlife,
+  everyday street life, or a historical scene).
+  Vary both the style and the subject so repeated runs differ.
+  Output only the prompt, max 80 words, no explanations or quotes.
+`;
+
+/**
+ * Generate a fresh MOTD image-generation prompt for the given location using
+ * an OpenAI-compatible chat client (OpenAI or xAI). Returns null on error or
+ * when the model produces no output, so callers can fall back to a stored
+ * prompt.
+ *
+ * @param client - OpenAI-compatible client
+ * @param model - chat model id to use
+ * @param location - configured location string (city, suburb, or full place name)
+ */
+export async function generateMotdImagePrompt(
+  client: OpenAI,
+  model: string,
+  location: string,
+): Promise<string | null> {
+  try {
+    const response = await client.responses.create({
+      model,
+      instructions: MOTD_IMAGE_PROMPT_INSTRUCTIONS,
+      input: location,
+    });
+
+    const imagePrompt = response.output_text.trim();
+    return imagePrompt.length > 0 ? imagePrompt : null;
+  } catch (error) {
+    console.error('Error generating MOTD image prompt:', error);
+    return null;
+  }
+}

--- a/src/services/chat/motd-image-prompt.ts
+++ b/src/services/chat/motd-image-prompt.ts
@@ -1,28 +1,6 @@
 import type OpenAI from 'openai';
 
 /**
- * Instructions for the LLM that crafts a MOTD image-generation prompt.
- *
- * The input is a configured location string, which may be a city, a suburb,
- * or a full place name (e.g. "Sea Point, Cape Town"). The whole configured
- * string is passed through verbatim so the model can use the full context.
- */
-export const MOTD_IMAGE_PROMPT_INSTRUCTIONS = `
-  You craft prompts for an AI image generator.
-  Given a location (which may be a city, a suburb, or a full place name),
-  output ONE vivid, detailed image-generation prompt depicting that place in
-  an interesting way.
-  Pick an evocative art style (for example: watercolour, oil painting,
-  ukiyo-e woodblock, retro travel poster, pixel art, art nouveau,
-  isometric illustration, comic book panel, or invent your own) and an
-  interesting subject (a landmark, hidden gem, local cuisine, market,
-  skyline at golden hour, natural landscape, festival, native wildlife,
-  everyday street life, or a historical scene).
-  Vary both the style and the subject so repeated runs differ.
-  Output only the prompt, max 80 words, no explanations or quotes.
-`;
-
-/**
  * Generate a fresh MOTD image-generation prompt for the given location using
  * an OpenAI-compatible chat client (OpenAI or xAI). Returns null on error or
  * when the model produces no output, so callers can fall back to a stored
@@ -30,17 +8,19 @@ export const MOTD_IMAGE_PROMPT_INSTRUCTIONS = `
  *
  * @param client - OpenAI-compatible client
  * @param model - chat model id to use
+ * @param instructions - system instructions from config (`config/motd-image-prompt.md`, hot-reloaded)
  * @param location - configured location string (city, suburb, or full place name)
  */
 export async function generateMotdImagePrompt(
   client: OpenAI,
   model: string,
+  instructions: string,
   location: string,
 ): Promise<string | null> {
   try {
     const response = await client.responses.create({
       model,
-      instructions: MOTD_IMAGE_PROMPT_INSTRUCTIONS,
+      instructions,
       input: location,
     });
 

--- a/src/services/openai/AGENTS.md
+++ b/src/services/openai/AGENTS.md
@@ -31,7 +31,7 @@ Behaviour:
 ## Other methods
 
 - `createImage(prompt)` — direct image generation via `images.generate`, used by the `/image` slash command and the daily MOTD.
-- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in `src/services/chat/motd-image-prompt.ts`; supplies this provider's client and `requireChatModel()`.
+- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in `src/services/chat/motd-image-prompt.ts`; supplies this provider's client, `requireChatModel()`, and the hot-reloaded instructions from `this._config.motdImagePrompt` (`config/motd-image-prompt.md`).
 - `generateThreadName(prompt)` — one-shot title generation, capped to 100 chars.
 - `reloadConfig(newConfig)` — hot-reload entry point.
 

--- a/src/services/openai/AGENTS.md
+++ b/src/services/openai/AGENTS.md
@@ -31,6 +31,7 @@ Behaviour:
 ## Other methods
 
 - `createImage(prompt)` — direct image generation via `images.generate`, used by the `/image` slash command and the daily MOTD.
+- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in `src/services/chat/motd-image-prompt.ts`; supplies this provider's client and `requireChatModel()`.
 - `generateThreadName(prompt)` — one-shot title generation, capped to 100 chars.
 - `reloadConfig(newConfig)` — hot-reload entry point.
 

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -369,6 +369,40 @@ class OpenAIService {
       throw new Error('Error creating thread name');
     }
   }
+
+  /**
+   * Ask the model to invent a fresh, vivid image-generation prompt for a city.
+   * Returns null on any failure so callers can fall back to a stored prompt.
+   */
+  async generateMotdImagePrompt(cityName: string): Promise<string | null> {
+    try {
+      const instructions = `
+        You craft prompts for an AI image generator.
+        Given a city name, output ONE vivid, detailed image-generation prompt
+        depicting that city in an interesting way.
+        Pick an evocative art style (for example: watercolour, oil painting,
+        ukiyo-e woodblock, retro travel poster, pixel art, art nouveau,
+        isometric illustration, comic book panel, or invent your own) and an
+        interesting subject (a landmark, hidden gem, local cuisine, market,
+        skyline at golden hour, natural landscape, festival, native wildlife,
+        everyday street life, or a historical scene).
+        Vary both the style and the subject so repeated runs differ.
+        Output only the prompt, max 80 words, no explanations or quotes.
+      `;
+
+      const response = await this._openai.responses.create({
+        model: this.requireChatModel(),
+        instructions,
+        input: cityName,
+      });
+
+      const imagePrompt = response.output_text.trim();
+      return imagePrompt.length > 0 ? imagePrompt : null;
+    } catch (error) {
+      console.error('Error generating MOTD image prompt:', error);
+      return null;
+    }
+  }
 }
 
 export default OpenAIService;

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -379,6 +379,7 @@ class OpenAIService {
     return generateMotdImagePrompt(
       this._openai,
       this.requireChatModel(),
+      this._config.motdImagePrompt,
       location,
     );
   }

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -8,6 +8,7 @@ import type {
   OpenAIResponse,
   ToolExecutor,
 } from '../../types.ts';
+import { generateMotdImagePrompt } from '../chat/motd-image-prompt.ts';
 import { FUNCTION_TOOLS } from './tools.ts';
 
 function renderPreferences(preferences: MemoryRow[]): string {
@@ -374,34 +375,12 @@ class OpenAIService {
    * Ask the model to invent a fresh, vivid image-generation prompt for a city.
    * Returns null on any failure so callers can fall back to a stored prompt.
    */
-  async generateMotdImagePrompt(cityName: string): Promise<string | null> {
-    try {
-      const instructions = `
-        You craft prompts for an AI image generator.
-        Given a city name, output ONE vivid, detailed image-generation prompt
-        depicting that city in an interesting way.
-        Pick an evocative art style (for example: watercolour, oil painting,
-        ukiyo-e woodblock, retro travel poster, pixel art, art nouveau,
-        isometric illustration, comic book panel, or invent your own) and an
-        interesting subject (a landmark, hidden gem, local cuisine, market,
-        skyline at golden hour, natural landscape, festival, native wildlife,
-        everyday street life, or a historical scene).
-        Vary both the style and the subject so repeated runs differ.
-        Output only the prompt, max 80 words, no explanations or quotes.
-      `;
-
-      const response = await this._openai.responses.create({
-        model: this.requireChatModel(),
-        instructions,
-        input: cityName,
-      });
-
-      const imagePrompt = response.output_text.trim();
-      return imagePrompt.length > 0 ? imagePrompt : null;
-    } catch (error) {
-      console.error('Error generating MOTD image prompt:', error);
-      return null;
-    }
+  async generateMotdImagePrompt(location: string): Promise<string | null> {
+    return generateMotdImagePrompt(
+      this._openai,
+      this.requireChatModel(),
+      location,
+    );
   }
 }
 

--- a/src/services/rooivalk/AGENTS.md
+++ b/src/services/rooivalk/AGENTS.md
@@ -43,15 +43,17 @@ The RooivalkService contains the core business logic for the bot. It processes m
 
 The daily MOTD uses a two-tier image fallback strategy:
 
-1. **AI-generated image** (primary): Calls `ImageService.createImage()` on the active image provider with a randomly composed prompt combining a style and city aspect for the selected city
+1. **AI-generated image** (primary): Calls `ImageService.createImage()` on the active image provider with the prompt for the selected location
 2. **Peapix** (fallback): Fetches Bing's image of the day via `PeapixService.getImage()`
 
-Image prompt composition uses two module-level arrays:
+The image prompt itself is also composed in two tiers, for variety:
 
-- `MOTD_IMAGE_STYLES` — 15 art styles (watercolour, pixel art, retro travel poster, etc.)
-- `MOTD_CITY_ASPECTS` — 12 subject topics (landmarks, cuisine, wildlife, etc.)
+1. **LLM-generated** (primary): `ImageService.generateMotdImagePrompt(location)` asks the chat model for a fresh prompt per location. The configured location string is passed through verbatim, so it may be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). The shared implementation lives in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt).
+2. **Stored style/aspect** (fallback): when the model is unavailable or returns nothing, a random combination of two module-level arrays is used —
+   - `MOTD_IMAGE_STYLES` — art styles (watercolour, pixel art, retro travel poster, etc.)
+   - `MOTD_CITY_ASPECTS` — subject topics (landmarks, cuisine, wildlife, etc.)
 
-A random style + aspect + city name are combined into the prompt each day for variety.
+The fallback combines a random style + aspect + location name into the prompt.
 
 ## Bot Behavior Logic
 

--- a/src/services/rooivalk/AGENTS.md
+++ b/src/services/rooivalk/AGENTS.md
@@ -48,7 +48,7 @@ The daily MOTD uses a two-tier image fallback strategy:
 
 The image prompt itself is also composed in two tiers, for variety:
 
-1. **LLM-generated** (primary): `ImageService.generateMotdImagePrompt(location)` asks the chat model for a fresh prompt per location. The configured location string is passed through verbatim, so it may be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). The shared implementation lives in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt).
+1. **LLM-generated** (primary): `ImageService.generateMotdImagePrompt(location)` asks the chat model for a fresh prompt per location. The configured location string is passed through verbatim, so it may be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). The shared implementation lives in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); the model's instructions are hot-reloaded from `config/motd-image-prompt.md` (`config.motdImagePrompt`), so the prompt can be tuned without a redeploy.
 2. **Stored style/aspect** (fallback): when the model is unavailable or returns nothing, a random combination of two module-level arrays is used —
    - `MOTD_IMAGE_STYLES` — art styles (watercolour, pixel art, retro travel poster, etc.)
    - `MOTD_CITY_ASPECTS` — subject topics (landmarks, cuisine, wildlife, etc.)

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -82,6 +82,7 @@ const mockOpenAIClient = vi.mocked({
   createResponse: vi.fn(),
   createImage: vi.fn(),
   generateThreadName: vi.fn(),
+  generateMotdImagePrompt: vi.fn(),
   reloadConfig: vi.fn(),
 } as any);
 
@@ -108,6 +109,7 @@ describe('Rooivalk', () => {
     mockChatClient.createResponse.mockResolvedValue('Mocked AI Response');
     mockChatClient.generateThreadName.mockResolvedValue('Thread Title');
     mockOpenAIClient.createImage.mockReset();
+    mockOpenAIClient.generateMotdImagePrompt.mockResolvedValue(null);
     mockPeapixService.getImage.mockResolvedValue(null);
     mockDiscordService.mentionRegex = new RegExp(`<@${BOT_ID}>`, 'g');
 
@@ -1344,8 +1346,158 @@ describe('Rooivalk', () => {
       expect(sendPayload?.embeds).toHaveLength(1);
     });
 
-    it('falls back to Peapix when AI image generation returns null', async () => {
-      mockOpenAIClient.createImage.mockResolvedValue(null);
+    it('uses the LLM-generated image prompt when available', async () => {
+      const motdConfig = {
+        ...MOCK_CONFIG,
+        motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
+      };
+      const motdContent = 'Good morning!';
+      const mockChannel = { isTextBased: () => true, send: vi.fn() };
+
+      Object.defineProperty(mockDiscordService, 'motdChannelId', {
+        get: () => 'motd-channel-id',
+        configurable: true,
+      });
+      Object.defineProperty(mockDiscordService, 'client', {
+        get: () => ({
+          user: { id: BOT_ID, tag: 'TestBot#0000' },
+          channels: { fetch: vi.fn().mockResolvedValue(mockChannel) },
+        }),
+        configurable: true,
+      });
+
+      mockDiscordService.getGuildEventsBetween.mockResolvedValue([]);
+      mockChatClient.createResponse.mockResolvedValue({
+        type: 'text',
+        content: motdContent,
+        base64Images: [],
+      });
+      mockDiscordService.buildMessageReply.mockReturnValue({
+        content: motdContent,
+      });
+
+      const generatedPrompt =
+        'A dreamy isometric illustration of a hidden rooftop garden.';
+      mockOpenAIClient.generateMotdImagePrompt.mockResolvedValue(
+        generatedPrompt,
+      );
+      mockOpenAIClient.createImage.mockResolvedValue(
+        Buffer.from('fake-image').toString('base64'),
+      );
+
+      const mockYrService = {
+        getAllForecasts: vi.fn().mockResolvedValue([]),
+      } as any;
+      const motdRooivalk = new Rooivalk(
+        motdConfig,
+        mockDiscordService,
+        mockChatClient,
+        mockOpenAIClient,
+        mockYrService,
+        mockPeapixService,
+      );
+
+      await motdRooivalk.sendMotdToMotdChannel();
+
+      expect(mockOpenAIClient.generateMotdImagePrompt).toHaveBeenCalledTimes(1);
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledWith(
+        generatedPrompt,
+      );
+    });
+
+    it('falls back to a stored style/aspect prompt when LLM prompt generation fails', async () => {
+      const motdConfig = {
+        ...MOCK_CONFIG,
+        motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
+      };
+      const motdContent = 'Good morning!';
+      const mockChannel = { isTextBased: () => true, send: vi.fn() };
+
+      Object.defineProperty(mockDiscordService, 'motdChannelId', {
+        get: () => 'motd-channel-id',
+        configurable: true,
+      });
+      Object.defineProperty(mockDiscordService, 'client', {
+        get: () => ({
+          user: { id: BOT_ID, tag: 'TestBot#0000' },
+          channels: { fetch: vi.fn().mockResolvedValue(mockChannel) },
+        }),
+        configurable: true,
+      });
+
+      mockDiscordService.getGuildEventsBetween.mockResolvedValue([]);
+      mockChatClient.createResponse.mockResolvedValue({
+        type: 'text',
+        content: motdContent,
+        base64Images: [],
+      });
+      mockDiscordService.buildMessageReply.mockReturnValue({
+        content: motdContent,
+      });
+
+      // generateMotdImagePrompt resolves null via beforeEach default.
+      mockOpenAIClient.createImage.mockResolvedValue(
+        Buffer.from('fake-image').toString('base64'),
+      );
+
+      const mockYrService = {
+        getAllForecasts: vi.fn().mockResolvedValue([]),
+      } as any;
+      const motdRooivalk = new Rooivalk(
+        motdConfig,
+        mockDiscordService,
+        mockChatClient,
+        mockOpenAIClient,
+        mockYrService,
+        mockPeapixService,
+      );
+
+      await motdRooivalk.sendMotdToMotdChannel();
+
+      expect(mockOpenAIClient.createImage).toHaveBeenCalledTimes(1);
+      const usedPrompt = mockOpenAIClient.createImage.mock.calls[0]?.[0];
+      expect(usedPrompt).toMatch(/Vivid, detailed, atmospheric\.$/);
+    });
+
+    it('falls back to Wikimedia when AI generation returns null', async () => {
+      const motdConfig = {
+        ...MOCK_CONFIG,
+        motd: 'Prompt {{WEATHER_FORECASTS_JSON}} {{EVENTS_JSON}}',
+      };
+      const motdContent = ['Intro line', 'Footer line'].join('\n');
+      const forecast = {
+        location: 'TABLEVIEW',
+        friendlyName: 'Table View, South Africa',
+        minTemp: 12,
+        maxTemp: 21,
+        avgWindSpeed: 4,
+        avgWindDirection: 'SE',
+        avgHumidity: 72,
+        totalPrecipitation: 0,
+      };
+      const mockChannel = { isTextBased: () => true, send: vi.fn() };
+
+      Object.defineProperty(mockDiscordService, 'motdChannelId', {
+        get: () => 'motd-channel-id',
+        configurable: true,
+      });
+      Object.defineProperty(mockDiscordService, 'client', {
+        get: () => ({
+          user: { id: BOT_ID, tag: 'TestBot#0000' },
+          channels: { fetch: vi.fn().mockResolvedValue(mockChannel) },
+        }),
+        configurable: true,
+      });
+
+      mockDiscordService.getGuildEventsBetween.mockResolvedValue([]);
+      mockChatClient.createResponse.mockResolvedValue({
+        type: 'text',
+        content: motdContent,
+        base64Images: [],
+      });
+      mockDiscordService.buildMessageReply.mockReturnValue({
+        content: motdContent,
+      });
       mockPeapixService.getImage.mockResolvedValue({
         title: 'Dune Patrol',
         copyright: '© Eric Yang/Getty Image',

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -99,6 +99,31 @@ const MOTD_IMAGE_STYLES = [
   'vintage postcard',
   'charcoal drawing',
   'comic book panel',
+  'gouache painting',
+  'ink wash painting',
+  'low-poly 3D render',
+  'cyberpunk neon illustration',
+  'steampunk illustration',
+  'minimalist flat vector art',
+  'surrealist painting',
+  'cubist painting',
+  'expressionist painting',
+  'baroque oil painting',
+  'fresco mural',
+  'linocut print',
+  'risograph print',
+  'cross-stitch embroidery',
+  'claymation diorama',
+  'paper cut-out collage',
+  'chalk pastel drawing',
+  'graffiti street mural',
+  'art deco poster',
+  'vaporwave aesthetic',
+  'storybook illustration',
+  'cinematic matte painting',
+  'silhouette illustration',
+  'mosaic tile artwork',
+  'blueprint technical drawing',
 ];
 
 const MOTD_CITY_ASPECTS = [
@@ -114,6 +139,23 @@ const MOTD_CITY_ASPECTS = [
   'wildlife native to the region',
   'the coastline or waterfront',
   'a historical scene from the past',
+  'a rainy night with reflections on the streets',
+  'a snowy winter morning',
+  'a view from a rooftop cafe',
+  'the old town quarter at dusk',
+  'a busy transit hub or train station',
+  'a tranquil park or garden',
+  'a vibrant nightlife district',
+  'a panoramic aerial view',
+  'a misty sunrise over the city',
+  'traditional local clothing and people',
+  'a beloved local sport or pastime',
+  'the river winding through the city',
+  'a famous bridge or crossing',
+  'an iconic local mode of transport',
+  'the city seen from a nearby hill',
+  'a quiet cobblestone alleyway',
+  'a seasonal scene unique to the region',
 ];
 
 class Rooivalk {
@@ -519,7 +561,24 @@ class Rooivalk {
         MOTD_IMAGE_STYLES[Math.floor(Math.random() * MOTD_IMAGE_STYLES.length)];
       const aspect =
         MOTD_CITY_ASPECTS[Math.floor(Math.random() * MOTD_CITY_ASPECTS.length)];
-      const imagePrompt = `${style} depicting ${aspect} of ${selectedCity.name}. Vivid, detailed, atmospheric.`;
+      const fallbackImagePrompt = `${style} depicting ${aspect} of ${selectedCity.name}. Vivid, detailed, atmospheric.`;
+
+      // Prefer a fresh LLM-generated prompt for variety; fall back to a random
+      // style/aspect combo if the model is unavailable or returns nothing.
+      let imagePrompt = fallbackImagePrompt;
+      try {
+        const generatedPrompt = await this._openai.generateMotdImagePrompt(
+          selectedCity.name,
+        );
+        if (generatedPrompt) {
+          imagePrompt = generatedPrompt;
+        }
+      } catch (err) {
+        console.error(
+          `AI image prompt generation failed for ${selectedCity.name}:`,
+          err,
+        );
+      }
 
       try {
         const base64Image = await this._openai.createImage(imagePrompt);

--- a/src/services/xai/AGENTS.md
+++ b/src/services/xai/AGENTS.md
@@ -10,6 +10,7 @@ The class is a deliberate parallel implementation rather than a subclass or an e
 
 - `createResponse(author, prompt, previousResponseId?, attachments?, toolExecutor?, preferences?)` — chat via the xAI Responses API, including the function-tool execution loop and the same 404 → retry-without-id flow that flips `contextLost: true`.
 - `createImage(prompt)` — direct image generation via `images.generate`. Requests `response_format: 'b64_json'` (the standard OpenAI-compat field) instead of OpenAI's `output_format` (which is `gpt-image-1`-specific).
+- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); supplies this provider's client and `requireChatModel()`.
 - `generateThreadName(prompt)` — one-shot thread title generation, capped to 100 chars.
 - `reloadConfig(newConfig)` — hot-reload entry point.
 

--- a/src/services/xai/AGENTS.md
+++ b/src/services/xai/AGENTS.md
@@ -10,7 +10,7 @@ The class is a deliberate parallel implementation rather than a subclass or an e
 
 - `createResponse(author, prompt, previousResponseId?, attachments?, toolExecutor?, preferences?)` — chat via the xAI Responses API, including the function-tool execution loop and the same 404 → retry-without-id flow that flips `contextLost: true`.
 - `createImage(prompt)` — direct image generation via `images.generate`. Requests `response_format: 'b64_json'` (the standard OpenAI-compat field) instead of OpenAI's `output_format` (which is `gpt-image-1`-specific).
-- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); supplies this provider's client and `requireChatModel()`.
+- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); supplies this provider's client, `requireChatModel()`, and the hot-reloaded instructions from `this._config.motdImagePrompt` (`config/motd-image-prompt.md`).
 - `generateThreadName(prompt)` — one-shot thread title generation, capped to 100 chars.
 - `reloadConfig(newConfig)` — hot-reload entry point.
 

--- a/src/services/xai/index.ts
+++ b/src/services/xai/index.ts
@@ -8,6 +8,7 @@ import type {
   OpenAIResponse,
   ToolExecutor,
 } from '../../types.ts';
+import { generateMotdImagePrompt } from '../chat/motd-image-prompt.ts';
 import { FUNCTION_TOOLS } from '../openai/tools.ts';
 
 const defaultInstructionsSelector: InstructionsSelector = (config) =>
@@ -353,34 +354,12 @@ class XAIService {
     }
   }
 
-  async generateMotdImagePrompt(cityName: string): Promise<string | null> {
-    try {
-      const instructions = `
-        You craft prompts for an AI image generator.
-        Given a city name, output ONE vivid, detailed image-generation prompt
-        depicting that city in an interesting way.
-        Pick an evocative art style (for example: watercolour, oil painting,
-        ukiyo-e woodblock, retro travel poster, pixel art, art nouveau,
-        isometric illustration, comic book panel, or invent your own) and an
-        interesting subject (a landmark, hidden gem, local cuisine, market,
-        skyline at golden hour, natural landscape, festival, native wildlife,
-        everyday street life, or a historical scene).
-        Vary both the style and the subject so repeated runs differ.
-        Output only the prompt, max 80 words, no explanations or quotes.
-      `;
-
-      const response = await this._xai.responses.create({
-        model: this.requireChatModel(),
-        instructions,
-        input: cityName,
-      });
-
-      const imagePrompt = response.output_text.trim();
-      return imagePrompt.length > 0 ? imagePrompt : null;
-    } catch (error) {
-      console.error('Error generating MOTD image prompt:', error);
-      return null;
-    }
+  async generateMotdImagePrompt(location: string): Promise<string | null> {
+    return generateMotdImagePrompt(
+      this._xai,
+      this.requireChatModel(),
+      location,
+    );
   }
 }
 

--- a/src/services/xai/index.ts
+++ b/src/services/xai/index.ts
@@ -352,6 +352,36 @@ class XAIService {
       throw new Error('Error creating thread name');
     }
   }
+
+  async generateMotdImagePrompt(cityName: string): Promise<string | null> {
+    try {
+      const instructions = `
+        You craft prompts for an AI image generator.
+        Given a city name, output ONE vivid, detailed image-generation prompt
+        depicting that city in an interesting way.
+        Pick an evocative art style (for example: watercolour, oil painting,
+        ukiyo-e woodblock, retro travel poster, pixel art, art nouveau,
+        isometric illustration, comic book panel, or invent your own) and an
+        interesting subject (a landmark, hidden gem, local cuisine, market,
+        skyline at golden hour, natural landscape, festival, native wildlife,
+        everyday street life, or a historical scene).
+        Vary both the style and the subject so repeated runs differ.
+        Output only the prompt, max 80 words, no explanations or quotes.
+      `;
+
+      const response = await this._xai.responses.create({
+        model: this.requireChatModel(),
+        instructions,
+        input: cityName,
+      });
+
+      const imagePrompt = response.output_text.trim();
+      return imagePrompt.length > 0 ? imagePrompt : null;
+    } catch (error) {
+      console.error('Error generating MOTD image prompt:', error);
+      return null;
+    }
+  }
 }
 
 export default XAIService;

--- a/src/services/xai/index.ts
+++ b/src/services/xai/index.ts
@@ -358,6 +358,7 @@ class XAIService {
     return generateMotdImagePrompt(
       this._xai,
       this.requireChatModel(),
+      this._config.motdImagePrompt,
       location,
     );
   }

--- a/src/test-utils/mock.ts
+++ b/src/test-utils/mock.ts
@@ -28,4 +28,5 @@ export const MOCK_CONFIG: InMemoryConfig = {
   profileInstructions: {},
   toolRoles: {},
   motd: 'Message of the day',
+  motdImagePrompt: 'Craft an image prompt for {{LOCATION}}',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ export type InMemoryConfig = {
   /** Role-based tool permissions, independent of channel profiles. */
   toolRoles: ToolRoles;
   motd: string;
+  /** Instructions the chat model follows to craft the daily MOTD image prompt. */
+  motdImagePrompt: string;
 };
 
 export type ResponseType =


### PR DESCRIPTION
## What

Adds hybrid image-prompt generation for the daily MOTD image. Instead of always building the image prompt from a fixed style/aspect template, the bot now asks the chat LLM to craft a fresh, varied prompt per city, falling back to the stored style/aspect combo when the model is unavailable or returns nothing.

## Changes

- `OpenAIService` / `XAIService`: new `generateMotdImagePrompt(cityName)` method (mirrored across both `ImageService` implementations) that requests a single vivid, ≤80-word image-generation prompt for the given city.
- `RooivalkService.sendMotdToMotdChannel()`: prefer the LLM-generated prompt for variety; fall back to a random `MOTD_IMAGE_STYLES` × `MOTD_CITY_ASPECTS` combo on error/empty. Image fallback chain remains **AI → Peapix → no-image**, all logged.
- Tests: cover the generated-prompt path and the stored-fallback path.

## Verification

- `tsc --noEmit` clean
- Full suite green: 272/272 tests, 18/18 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)