### PR TITLE
feat: persist MOTD memory to avoid repeating cities and prompts

### DIFF
--- a/src/services/chat/AGENTS.md
+++ b/src/services/chat/AGENTS.md
@@ -81,10 +81,17 @@ When adding a new tool:
 `motd-image-prompt.ts` holds the shared request logic for the daily MOTD image
 prompt, used by both provider classes so they stay in sync.
 
-- `generateMotdImagePrompt(client, model, instructions, location)` — runs the
-  request against any OpenAI-compatible client (`_openai` or `_xai`) and returns
-  the prompt, or `null` on error / empty output so callers can fall back to a
-  stored prompt.
+- `generateMotdImagePrompt(client, model, instructions, location, recentPrompts)`
+  — runs the request against any OpenAI-compatible client (`_openai` or `_xai`)
+  and returns the prompt, or `null` on error / empty output so callers can fall
+  back to a stored prompt.
+
+`recentPrompts` (newest first, may be empty) is appended to the instructions as
+an "avoid anything similar to these" list, so the model deliberately picks a
+different style and subject than it used on recent days. Blank entries are
+skipped; an empty list adds nothing. `RooivalkService` supplies these from
+`MemoryService.getRecentMotdPrompts()` and records each new prompt via
+`recordMotdPrompt()` (see `src/services/memory/AGENTS.md`).
 
 The system instructions are **not** hardcoded — they live in
 `config/motd-image-prompt.md` and are hot-reloaded into `config.motdImagePrompt`

--- a/src/services/chat/motd-image-prompt.test.ts
+++ b/src/services/chat/motd-image-prompt.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { generateMotdImagePrompt } from './motd-image-prompt.ts';
+
+const makeClient = (output: string) => {
+  const create = vi.fn().mockResolvedValue({ output_text: output });
+  return {
+    client: { responses: { create } } as never,
+    create,
+  };
+};
+
+describe('generateMotdImagePrompt', () => {
+  it('returns the trimmed model output', async () => {
+    const { client } = makeClient('  a vivid prompt  ');
+    const result = await generateMotdImagePrompt(
+      client,
+      'model-x',
+      'base instructions',
+      'Cape Town',
+    );
+    expect(result).toBe('a vivid prompt');
+  });
+
+  it('passes the base instructions and location through', async () => {
+    const { client, create } = makeClient('prompt');
+    await generateMotdImagePrompt(
+      client,
+      'model-x',
+      'base instructions',
+      'Cape Town',
+    );
+    const args = create.mock.calls[0]![0];
+    expect(args.model).toBe('model-x');
+    expect(args.input).toBe('Cape Town');
+    expect(args.instructions).toContain('base instructions');
+  });
+
+  it('appends recent prompts as an avoid-list', async () => {
+    const { client, create } = makeClient('prompt');
+    await generateMotdImagePrompt(
+      client,
+      'model-x',
+      'base instructions',
+      'Cape Town',
+      ['watercolour of Dubai', 'retro travel poster of Gdańsk'],
+    );
+    const { instructions } = create.mock.calls[0]![0];
+    expect(instructions).toContain('Do NOT produce a prompt similar');
+    expect(instructions).toContain('- watercolour of Dubai');
+    expect(instructions).toContain('- retro travel poster of Gdańsk');
+  });
+
+  it('omits the avoid-list when there are no recent prompts', async () => {
+    const { client, create } = makeClient('prompt');
+    await generateMotdImagePrompt(client, 'model-x', 'base', 'Cape Town', []);
+    const { instructions } = create.mock.calls[0]![0];
+    expect(instructions).not.toContain('Do NOT produce a prompt similar');
+  });
+
+  it('skips blank recent prompts', async () => {
+    const { client, create } = makeClient('prompt');
+    await generateMotdImagePrompt(client, 'model-x', 'base', 'Cape Town', [
+      '   ',
+    ]);
+    const { instructions } = create.mock.calls[0]![0];
+    expect(instructions).not.toContain('Do NOT produce a prompt similar');
+  });
+
+  it('returns null when the model output is empty', async () => {
+    const { client } = makeClient('   ');
+    const result = await generateMotdImagePrompt(
+      client,
+      'model-x',
+      'base',
+      'Cape Town',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null and logs when the request throws', async () => {
+    const create = vi.fn().mockRejectedValue(new Error('boom'));
+    const client = { responses: { create } } as never;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await generateMotdImagePrompt(
+      client,
+      'model-x',
+      'base',
+      'Cape Town',
+    );
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/src/services/chat/motd-image-prompt.ts
+++ b/src/services/chat/motd-image-prompt.ts
@@ -1,6 +1,20 @@
 import type OpenAI from 'openai';
 
 /**
+ * Builds the avoid-list block appended to the instructions so the model steers
+ * away from prompts it recently produced. Returns an empty string when there is
+ * nothing to avoid.
+ */
+const buildAvoidBlock = (recentPrompts: readonly string[]): string => {
+  const cleaned = recentPrompts.map((p) => p.trim()).filter(Boolean);
+  if (cleaned.length === 0) {
+    return '';
+  }
+  const list = cleaned.map((p) => `- ${p}`).join('\n');
+  return `\n\nDo NOT produce a prompt similar in art style or subject to any of these recent ones. Deliberately pick a different style and subject:\n${list}`;
+};
+
+/**
  * Generate a fresh MOTD image-generation prompt for the given location using
  * an OpenAI-compatible chat client (OpenAI or xAI). Returns null on error or
  * when the model produces no output, so callers can fall back to a stored
@@ -10,17 +24,19 @@ import type OpenAI from 'openai';
  * @param model - chat model id to use
  * @param instructions - system instructions from config (`config/motd-image-prompt.md`, hot-reloaded)
  * @param location - configured location string (city, suburb, or full place name)
+ * @param recentPrompts - recently used prompts to steer away from (newest first)
  */
 export async function generateMotdImagePrompt(
   client: OpenAI,
   model: string,
   instructions: string,
   location: string,
+  recentPrompts: readonly string[] = [],
 ): Promise<string | null> {
   try {
     const response = await client.responses.create({
       model,
-      instructions,
+      instructions: `${instructions}${buildAvoidBlock(recentPrompts)}`,
       input: location,
     });
 

--- a/src/services/memory/AGENTS.md
+++ b/src/services/memory/AGENTS.md
@@ -6,6 +6,7 @@
 
 1. **Memories** — free-form notes the model decides to keep about a user (`memory` kind), plus a capped set of stable user preferences (`preference` kind) injected into every turn.
 2. **Conversation response ids** — per-conversation OpenAI `response.id` values used to chain turns via `previous_response_id`.
+3. **MOTD image history** — the city rotation cycle and recent image prompts that keep the daily MOTD image varied (see MOTD section below).
 
 The service holds two connections to the same DB file: a writable one for mutations and a `readOnly: true` one used for reads (`recall`, `getPreferences`, `forgetMemory` lookup, `getConversationResponseId`, ad-hoc `query`). Read-only is enforced **at the SQLite level**, so even a programming bug that issues a write through the read handle fails in the engine.
 
@@ -19,6 +20,16 @@ The service holds two connections to the same DB file: a writable one for mutati
 
 - `memories(id, discord_user_id, content, kind, created_at)` — composite index on `(discord_user_id, kind)`. `kind` is `'memory'` or `'preference'`, enforced by a CHECK constraint.
 - `conversation_responses(type, ref_id, response_id, updated_at)` — composite PK on `(type, ref_id)`. `type` is `'msg'` (a bot reply id) or `'thread'` (a thread id), enforced by a CHECK constraint. Upserted via `ON CONFLICT(type, ref_id)`. Read/written via `getConversationResponseId(ref)` / `setConversationResponseId(ref, id)` / `clearConversationResponseId(ref)`. Index on `updated_at` supports the TTL prune. `pruneConversationResponses(olderThanMs)` deletes any row past its expiry — wired to a daily cron in `src/index.ts` with `CONVERSATION_RESPONSE_TTL_MS` (30 days) since OpenAI's response retention window is the upper bound on usefulness.
+- `motd_city_rotation(city, used_at)` — cities used in the current MOTD rotation cycle. `city` is the PK.
+- `motd_prompt_history(id, prompt, created_at)` — recent MOTD image prompts, pruned to the newest N. Index on `created_at` supports ordered recall and pruning.
+
+## MOTD image variety
+
+These methods keep the daily MOTD image from repeating, and back the city rotation and recent-prompt avoidance in `RooivalkService.sendMotdToMotdChannel()`:
+
+- `pickMotdCity(cities)` — returns a city not yet used in the current cycle, recording the pick atomically (wrapped in `BEGIN IMMEDIATE` so concurrent calls can't double-pick or skip the reset). When every city has been used the rotation table is cleared and the cycle restarts, so no city repeats until all have appeared. Throws on an empty list.
+- `recordMotdPrompt(prompt, keep = 20)` — stores a prompt and prunes the history to the newest `keep` rows. Blank prompts are ignored.
+- `getRecentMotdPrompts(limit = 10)` — returns recent prompts newest-first; fed to the model as an avoid-list so it steers away from repeating a style or subject.
 
 ## Memory kinds
 
@@ -40,7 +51,7 @@ Every memory tool resolves the subject from `message.author.id` at the **executo
 ## Testing
 
 - Tests use a temp directory (`mkdtempSync` in `os.tmpdir()`). `:memory:` won't work because two connections to it are independent DBs.
-- `index.test.ts` covers: writes, scoped recall, limit clamping, cross-user delete refusal, structural read-only enforcement, ad-hoc `query` (parameterised SELECT, row-limit truncation, write rejection), persistence across reopens.
+- `index.test.ts` covers: writes, scoped recall, limit clamping, cross-user delete refusal, structural read-only enforcement, ad-hoc `query` (parameterised SELECT, row-limit truncation, write rejection), persistence across reopens, MOTD city rotation (no repeat until cycle reset, single-city lists, persistence) and MOTD prompt history (ordering, pruning, blank handling).
 
 ## Out of Scope (for now)
 

--- a/src/services/memory/index.test.ts
+++ b/src/services/memory/index.test.ts
@@ -134,6 +134,86 @@ describe('MemoryService', () => {
     });
   });
 
+  describe('MOTD city rotation', () => {
+    const CITIES = ['Cape Town', 'Gdańsk', 'Dubai'];
+
+    it('throws when the city list is empty', () => {
+      expect(() => memory.pickMotdCity([])).toThrow(/empty list/);
+    });
+
+    it('returns a city from the provided list', () => {
+      const city = memory.pickMotdCity(CITIES);
+      expect(CITIES).toContain(city);
+    });
+
+    it('does not repeat a city until all have been used, then resets', () => {
+      const first = memory.pickMotdCity(CITIES);
+      const second = memory.pickMotdCity(CITIES);
+      const third = memory.pickMotdCity(CITIES);
+
+      // First full cycle covers every city exactly once.
+      expect(new Set([first, second, third])).toEqual(new Set(CITIES));
+
+      // Cycle reset: the fourth pick is allowed to be any city again.
+      const fourth = memory.pickMotdCity(CITIES);
+      expect(CITIES).toContain(fourth);
+      // The rotation table now holds only the post-reset pick.
+      const { rows } = memory.query('SELECT city FROM motd_city_rotation');
+      expect(rows).toEqual([{ city: fourth }]);
+    });
+
+    it('handles a single-city list by resetting each time', () => {
+      expect(memory.pickMotdCity(['Solo'])).toBe('Solo');
+      expect(memory.pickMotdCity(['Solo'])).toBe('Solo');
+    });
+
+    it('persists rotation state across reopens', () => {
+      const first = memory.pickMotdCity(CITIES);
+      memory.close();
+      memory = new MemoryService(dbPath);
+      const second = memory.pickMotdCity(CITIES);
+      expect(second).not.toBe(first);
+    });
+  });
+
+  describe('MOTD prompt history', () => {
+    it('records prompts and returns them newest first', () => {
+      memory.recordMotdPrompt('first prompt');
+      memory.recordMotdPrompt('second prompt');
+      expect(memory.getRecentMotdPrompts()).toEqual([
+        'second prompt',
+        'first prompt',
+      ]);
+    });
+
+    it('ignores empty prompts', () => {
+      memory.recordMotdPrompt('   ');
+      expect(memory.getRecentMotdPrompts()).toHaveLength(0);
+    });
+
+    it('prunes history to the newest `keep` rows', () => {
+      for (let i = 0; i < 5; i++) {
+        memory.recordMotdPrompt(`prompt ${i}`, 3);
+      }
+      const recent = memory.getRecentMotdPrompts();
+      expect(recent).toEqual(['prompt 4', 'prompt 3', 'prompt 2']);
+    });
+
+    it('respects the recall limit', () => {
+      for (let i = 0; i < 4; i++) {
+        memory.recordMotdPrompt(`p${i}`);
+      }
+      expect(memory.getRecentMotdPrompts(2)).toEqual(['p3', 'p2']);
+    });
+
+    it('persists prompt history across reopens', () => {
+      memory.recordMotdPrompt('durable prompt');
+      memory.close();
+      memory = new MemoryService(dbPath);
+      expect(memory.getRecentMotdPrompts()).toEqual(['durable prompt']);
+    });
+  });
+
   describe('read-only handle', () => {
     it('rejects writes at the SQLite level', () => {
       const readDb = (

--- a/src/services/memory/index.ts
+++ b/src/services/memory/index.ts
@@ -184,6 +184,86 @@ class MemoryService {
     return result.changes as number;
   }
 
+  /**
+   * Picks a MOTD city from `cities`, avoiding any used in the current rotation
+   * cycle. When every city has been used the rotation resets and starts over,
+   * so no city repeats until all of them have appeared. The pick is recorded
+   * atomically. Returns the chosen city name.
+   */
+  public pickMotdCity(cities: readonly string[]): string {
+    if (cities.length === 0) {
+      throw new Error('Cannot pick a MOTD city from an empty list');
+    }
+
+    this._writeDb.exec('BEGIN IMMEDIATE');
+    let committed = false;
+    try {
+      const usedRows = this._writeDb
+        .prepare('SELECT city FROM motd_city_rotation')
+        .all() as { city: string }[];
+      const used = new Set(usedRows.map((r) => r.city));
+
+      let available = cities.filter((c) => !used.has(c));
+      if (available.length === 0) {
+        // Every city has been used — reset the cycle and start over.
+        this._writeDb.exec('DELETE FROM motd_city_rotation');
+        available = [...cities];
+      }
+
+      const chosen = available[Math.floor(Math.random() * available.length)]!;
+      this._writeDb
+        .prepare(
+          'INSERT OR REPLACE INTO motd_city_rotation (city, used_at) VALUES (?, ?)',
+        )
+        .run(chosen, Date.now());
+
+      this._writeDb.exec('COMMIT');
+      committed = true;
+      return chosen;
+    } finally {
+      if (!committed) {
+        this._writeDb.exec('ROLLBACK');
+      }
+    }
+  }
+
+  /**
+   * Records a MOTD image prompt and prunes the history to the newest `keep`
+   * rows, so the recent-prompt context stays bounded.
+   */
+  public recordMotdPrompt(prompt: string, keep = 20): void {
+    const trimmed = prompt?.trim();
+    if (!trimmed) {
+      return;
+    }
+    this._writeDb
+      .prepare(
+        'INSERT INTO motd_prompt_history (prompt, created_at) VALUES (?, ?)',
+      )
+      .run(trimmed, Date.now());
+
+    const safeKeep = Math.max(0, Math.floor(keep));
+    this._writeDb
+      .prepare(
+        `DELETE FROM motd_prompt_history
+         WHERE id NOT IN (
+           SELECT id FROM motd_prompt_history ORDER BY created_at DESC, id DESC LIMIT ?
+         )`,
+      )
+      .run(safeKeep);
+  }
+
+  /** Returns the most recent MOTD image prompts, newest first. */
+  public getRecentMotdPrompts(limit = 10): string[] {
+    const safeLimit = Math.min(Math.max(1, Math.floor(limit)), 100);
+    const rows = this._readDb
+      .prepare(
+        'SELECT prompt FROM motd_prompt_history ORDER BY created_at DESC, id DESC LIMIT ?',
+      )
+      .all(safeLimit) as { prompt: string }[];
+    return rows.map((r) => r.prompt);
+  }
+
   public close(): void {
     if (this._closed) {
       return;

--- a/src/services/memory/schema.ts
+++ b/src/services/memory/schema.ts
@@ -19,4 +19,18 @@ CREATE TABLE IF NOT EXISTS conversation_responses (
 
 CREATE INDEX IF NOT EXISTS idx_conversation_responses_updated_at
   ON conversation_responses(updated_at);
+
+CREATE TABLE IF NOT EXISTS motd_city_rotation (
+  city TEXT PRIMARY KEY,
+  used_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS motd_prompt_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  prompt TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_motd_prompt_history_created_at
+  ON motd_prompt_history(created_at);
 `;

--- a/src/services/openai/AGENTS.md
+++ b/src/services/openai/AGENTS.md
@@ -31,7 +31,7 @@ Behaviour:
 ## Other methods
 
 - `createImage(prompt)` — direct image generation via `images.generate`, used by the `/image` slash command and the daily MOTD.
-- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in `src/services/chat/motd-image-prompt.ts`; supplies this provider's client, `requireChatModel()`, and the hot-reloaded instructions from `this._config.motdImagePrompt` (`config/motd-image-prompt.md`).
+- `generateMotdImagePrompt(location, recentPrompts?)` — asks the chat model for a fresh MOTD image prompt for the given location, steering away from `recentPrompts`. Thin wrapper over the shared helper in `src/services/chat/motd-image-prompt.ts`; supplies this provider's client, `requireChatModel()`, and the hot-reloaded instructions from `this._config.motdImagePrompt` (`config/motd-image-prompt.md`).
 - `generateThreadName(prompt)` — one-shot title generation, capped to 100 chars.
 - `reloadConfig(newConfig)` — hot-reload entry point.
 

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -375,12 +375,16 @@ class OpenAIService {
    * Ask the model to invent a fresh, vivid image-generation prompt for a city.
    * Returns null on any failure so callers can fall back to a stored prompt.
    */
-  async generateMotdImagePrompt(location: string): Promise<string | null> {
+  async generateMotdImagePrompt(
+    location: string,
+    recentPrompts: readonly string[] = [],
+  ): Promise<string | null> {
     return generateMotdImagePrompt(
       this._openai,
       this.requireChatModel(),
       this._config.motdImagePrompt,
       location,
+      recentPrompts,
     );
   }
 }

--- a/src/services/rooivalk/AGENTS.md
+++ b/src/services/rooivalk/AGENTS.md
@@ -48,12 +48,19 @@ The daily MOTD uses a two-tier image fallback strategy:
 
 The image prompt itself is also composed in two tiers, for variety:
 
-1. **LLM-generated** (primary): `ImageService.generateMotdImagePrompt(location)` asks the chat model for a fresh prompt per location. The configured location string is passed through verbatim, so it may be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). The shared implementation lives in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); the model's instructions are hot-reloaded from `config/motd-image-prompt.md` (`config.motdImagePrompt`), so the prompt can be tuned without a redeploy.
+1. **LLM-generated** (primary): `ImageService.generateMotdImagePrompt(location, recentPrompts)` asks the chat model for a fresh prompt per location. The configured location string is passed through verbatim, so it may be a city, a suburb, or a full place name (e.g. `Sea Point, Cape Town`). The shared implementation lives in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); the model's instructions are hot-reloaded from `config/motd-image-prompt.md` (`config.motdImagePrompt`), so the prompt can be tuned without a redeploy.
 2. **Stored style/aspect** (fallback): when the model is unavailable or returns nothing, a random combination of two module-level arrays is used —
    - `MOTD_IMAGE_STYLES` — art styles (watercolour, pixel art, retro travel poster, etc.)
    - `MOTD_CITY_ASPECTS` — subject topics (landmarks, cuisine, wildlife, etc.)
 
 The fallback combines a random style + aspect + location name into the prompt.
+
+#### Avoiding repetition (memory)
+
+Both the city choice and the prompt are de-duplicated across days via `MemoryService` (persisted in SQLite, so it survives restarts — see [`src/services/memory/AGENTS.md`](../memory/AGENTS.md#motd-image-variety)):
+
+- **City rotation**: `pickMotdCity(cityNames)` picks a `YR_COORDINATES` location that hasn't been used in the current cycle. No city repeats until every one has appeared, then the cycle resets.
+- **Prompt avoidance**: `getRecentMotdPrompts()` feeds recent prompts into the LLM call as an avoid-list, and the chosen prompt is saved with `recordMotdPrompt()`. This is what stops the model defaulting to the same style (e.g. "retro travel poster") every day.
 
 ## Bot Behavior Logic
 

--- a/src/services/rooivalk/index.test.ts
+++ b/src/services/rooivalk/index.test.ts
@@ -75,6 +75,9 @@ const mockMemoryService = vi.mocked({
   recall: vi.fn(),
   remember: vi.fn(),
   forgetMemory: vi.fn(),
+  pickMotdCity: vi.fn().mockReturnValue('Test City, Testland'),
+  getRecentMotdPrompts: vi.fn().mockReturnValue([]),
+  recordMotdPrompt: vi.fn(),
   close: vi.fn(),
 } as any);
 
@@ -110,6 +113,8 @@ describe('Rooivalk', () => {
     mockChatClient.generateThreadName.mockResolvedValue('Thread Title');
     mockOpenAIClient.createImage.mockReset();
     mockOpenAIClient.generateMotdImagePrompt.mockResolvedValue(null);
+    mockMemoryService.pickMotdCity.mockReturnValue('Test City, Testland');
+    mockMemoryService.getRecentMotdPrompts.mockReturnValue([]);
     mockPeapixService.getImage.mockResolvedValue(null);
     mockDiscordService.mentionRegex = new RegExp(`<@${BOT_ID}>`, 'g');
 
@@ -1125,6 +1130,8 @@ describe('Rooivalk', () => {
         mockOpenAIClient,
         mockYrService,
         mockPeapixService,
+        undefined,
+        mockMemoryService,
       );
 
       await weatherRooivalk.handleWeatherCommand(interaction);
@@ -1153,6 +1160,8 @@ describe('Rooivalk', () => {
         mockOpenAIClient,
         mockYrService,
         mockPeapixService,
+        undefined,
+        mockMemoryService,
       );
 
       await weatherRooivalk.handleWeatherCommand(interaction);
@@ -1183,6 +1192,8 @@ describe('Rooivalk', () => {
         mockOpenAIClient,
         mockYrService,
         mockPeapixService,
+        undefined,
+        mockMemoryService,
       );
 
       await weatherRooivalk.handleWeatherCommand(interaction);
@@ -1330,6 +1341,8 @@ describe('Rooivalk', () => {
         mockOpenAIClient,
         mockYrService,
         mockPeapixService,
+        undefined,
+        mockMemoryService,
       );
 
     it('uses the AI-generated image when createImage succeeds', async () => {
@@ -1344,6 +1357,43 @@ describe('Rooivalk', () => {
       const sendPayload = mockChannel.send.mock.calls[0]?.[0];
       expect(sendPayload?.files).toHaveLength(1);
       expect(sendPayload?.embeds).toHaveLength(1);
+    });
+
+    it('rotates cities and passes recent prompts to the model, then records the prompt', async () => {
+      mockMemoryService.pickMotdCity.mockReturnValue('Gdańsk, Poland');
+      mockMemoryService.getRecentMotdPrompts.mockReturnValue([
+        'watercolour of Dubai',
+      ]);
+      mockOpenAIClient.generateMotdImagePrompt.mockResolvedValue(
+        'oil painting of a Gdańsk market',
+      );
+      mockOpenAIClient.createImage.mockResolvedValue(
+        Buffer.from('img').toString('base64'),
+      );
+
+      await buildRooivalk().sendMotdToMotdChannel();
+
+      // City rotation drives selection from the configured location names.
+      expect(mockMemoryService.pickMotdCity).toHaveBeenCalledTimes(1);
+      const cityArg = mockMemoryService.pickMotdCity.mock.calls[0]![0];
+      expect(cityArg).toContain('Dubai, United Arab Emirates');
+
+      // Recent prompts are forwarded to the prompt generator for the chosen city.
+      expect(mockOpenAIClient.generateMotdImagePrompt).toHaveBeenCalledWith(
+        'Gdańsk, Poland',
+        ['watercolour of Dubai'],
+      );
+
+      // The final prompt is recorded so future MOTDs steer away from it.
+      expect(mockMemoryService.recordMotdPrompt).toHaveBeenCalledWith(
+        'oil painting of a Gdańsk market',
+      );
+
+      // The chosen city is used as the image heading (embed description).
+      const sendPayload = mockChannel.send.mock.calls[0]?.[0];
+      expect(sendPayload?.embeds?.[0]?.data?.description).toContain(
+        'Gdańsk, Poland',
+      );
     });
 
     it('uses the LLM-generated image prompt when available', async () => {
@@ -1395,6 +1445,8 @@ describe('Rooivalk', () => {
         mockOpenAIClient,
         mockYrService,
         mockPeapixService,
+        undefined,
+        mockMemoryService,
       );
 
       await motdRooivalk.sendMotdToMotdChannel();
@@ -1450,6 +1502,8 @@ describe('Rooivalk', () => {
         mockOpenAIClient,
         mockYrService,
         mockPeapixService,
+        undefined,
+        mockMemoryService,
       );
 
       await motdRooivalk.sendMotdToMotdChannel();

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -55,13 +55,6 @@ import {
 import { buildToolExecutor } from './tool-executor.ts';
 import type { ToolExecutor } from '../../types.ts';
 
-function shuffleArray<T>(items: T[]): T[] {
-  return items
-    .map((item) => ({ item, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ item }) => item);
-}
-
 const MOTD_IMAGE_ATTACHMENT_NAME = 'rooivalk_motd.jpg';
 
 const LEADERBOARD_EMBED_COLOR = 0xe74c3c;
@@ -553,45 +546,51 @@ class Rooivalk {
         buffer: Buffer;
       } | null = null;
 
-      const locations = Object.values(YR_COORDINATES);
-      const shuffled = shuffleArray(locations);
-      const selectedCity = shuffled[0];
+      // Rotate through the cities so none repeats until all have been used,
+      // and gather recent prompts so the model can steer away from them.
+      const cityNames = Object.values(YR_COORDINATES).map((l) => l.name);
+      const selectedCityName = this._memory.pickMotdCity(cityNames);
+      const recentPrompts = this._memory.getRecentMotdPrompts();
 
       const style =
         MOTD_IMAGE_STYLES[Math.floor(Math.random() * MOTD_IMAGE_STYLES.length)];
       const aspect =
         MOTD_CITY_ASPECTS[Math.floor(Math.random() * MOTD_CITY_ASPECTS.length)];
-      const fallbackImagePrompt = `${style} depicting ${aspect} of ${selectedCity.name}. Vivid, detailed, atmospheric.`;
+      const fallbackImagePrompt = `${style} depicting ${aspect} of ${selectedCityName}. Vivid, detailed, atmospheric.`;
 
       // Prefer a fresh LLM-generated prompt for variety; fall back to a random
       // style/aspect combo if the model is unavailable or returns nothing.
       let imagePrompt = fallbackImagePrompt;
       try {
         const generatedPrompt = await this._openai.generateMotdImagePrompt(
-          selectedCity.name,
+          selectedCityName,
+          recentPrompts,
         );
         if (generatedPrompt) {
           imagePrompt = generatedPrompt;
         }
       } catch (err) {
         console.error(
-          `AI image prompt generation failed for ${selectedCity.name}:`,
+          `AI image prompt generation failed for ${selectedCityName}:`,
           err,
         );
       }
+
+      // Remember the chosen prompt so future MOTDs avoid repeating it.
+      this._memory.recordMotdPrompt(imagePrompt);
 
       try {
         const base64Image = await this._openai.createImage(imagePrompt);
         if (base64Image) {
           motdImage = {
-            heading: selectedCity.name,
+            heading: selectedCityName,
             attribution: imagePrompt,
             buffer: Buffer.from(base64Image, 'base64'),
           };
         }
       } catch (err) {
         console.error(
-          `AI image generation failed for ${selectedCity.name}:`,
+          `AI image generation failed for ${selectedCityName}:`,
           err,
         );
       }

--- a/src/services/xai/AGENTS.md
+++ b/src/services/xai/AGENTS.md
@@ -10,7 +10,7 @@ The class is a deliberate parallel implementation rather than a subclass or an e
 
 - `createResponse(author, prompt, previousResponseId?, attachments?, toolExecutor?, preferences?)` — chat via the xAI Responses API, including the function-tool execution loop and the same 404 → retry-without-id flow that flips `contextLost: true`.
 - `createImage(prompt)` — direct image generation via `images.generate`. Requests `response_format: 'b64_json'` (the standard OpenAI-compat field) instead of OpenAI's `output_format` (which is `gpt-image-1`-specific).
-- `generateMotdImagePrompt(location)` — asks the chat model for a fresh MOTD image prompt for the given location. Thin wrapper over the shared helper in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); supplies this provider's client, `requireChatModel()`, and the hot-reloaded instructions from `this._config.motdImagePrompt` (`config/motd-image-prompt.md`).
+- `generateMotdImagePrompt(location, recentPrompts?)` — asks the chat model for a fresh MOTD image prompt for the given location, steering away from `recentPrompts`. Thin wrapper over the shared helper in [`src/services/chat/motd-image-prompt.ts`](../chat/AGENTS.md#motd-image-prompt); supplies this provider's client, `requireChatModel()`, and the hot-reloaded instructions from `this._config.motdImagePrompt` (`config/motd-image-prompt.md`).
 - `generateThreadName(prompt)` — one-shot thread title generation, capped to 100 chars.
 - `reloadConfig(newConfig)` — hot-reload entry point.
 

--- a/src/services/xai/index.ts
+++ b/src/services/xai/index.ts
@@ -354,12 +354,16 @@ class XAIService {
     }
   }
 
-  async generateMotdImagePrompt(location: string): Promise<string | null> {
+  async generateMotdImagePrompt(
+    location: string,
+    recentPrompts: readonly string[] = [],
+  ): Promise<string | null> {
     return generateMotdImagePrompt(
       this._xai,
       this.requireChatModel(),
       this._config.motdImagePrompt,
       location,
+      recentPrompts,
     );
   }
 }


### PR DESCRIPTION
## What

The daily MOTD image had grown monotonous — same art style and cities repeating across days. A stateless one-shot LLM call can't vary across days on its own, so the variation now comes from **persisted state** in `MemoryService` (SQLite, survives restarts).

## Changes

- **Schema**: two new tables — `motd_city_rotation(city, used_at)` and `motd_prompt_history(id, prompt, created_at)` (`IF NOT EXISTS`, no migration framework needed).
- **`MemoryService`**:
  - `pickMotdCity(cities)` — picks a city not used in the current cycle and records it atomically (`BEGIN IMMEDIATE`). No city repeats until every one has appeared, then the cycle resets.
  - `recordMotdPrompt(prompt, keep=20)` / `getRecentMotdPrompts(limit=10)` — store and recall recent prompts.
- **`generateMotdImagePrompt`**: new `recentPrompts` param appended to the instructions as an "avoid anything similar to these" list, so the model deliberately picks a different style/subject. Mirrored across `OpenAIService` and `XAIService`.
- **`RooivalkService.sendMotdToMotdChannel()`**: uses the rotation + recent prompts, records the chosen prompt, drops the blind shuffle (and dead `shuffleArray`).

## Verification

- `tsc --noEmit` clean
- Full suite green: **290/290 tests, 19/19 files** (+18 tests, +1 file)
- New coverage: memory rotation + history, helper avoid-list injection, Rooivalk wiring. Also passes the memory mock into the MOTD/weather test constructions for proper isolation (they were instantiating a real DB).

## Notes

State lives in the DB (`ROOIVALK_DB_PATH`), not config — it's runtime state, so it does not hot-reload like the prompt text. Variety persists across restarts/deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)