### PR TITLE
Add GitHub issue create/search chat tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ ROOIVALK_MOTD_CRON="0 8 * * *"
 ROOIVALK_LEADERBOARD_CRON="5 8 * * 3"
 ROOIVALK_DB_PATH=./data/rooivalk.db
 STEAM_API_KEY=your_steam_web_api_key
+# Optional: fine-grained GitHub PAT with Issues read/write on the repos listed
+# in GITHUB_REPOS (src/constants.ts). Enables the create/search issue tools.
+GITHUB_TOKEN=your_github_personal_access_token
 # Optional: set to "debug" to log prompt metrics (instruction/prompt lengths,
 # attachment counts, previous_response_id presence) on every chat call.
 LOG_LEVEL=info

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ The codebase uses a modular, service-based architecture. All services are TypeSc
 - `src/services/yr/` – YrService (weather integration) - [See AGENTS.md](src/services/yr/AGENTS.md)
 - `src/services/peapix/` – PeapixService (Bing image-of-the-day fallback for MOTD) - [See AGENTS.md](src/services/peapix/AGENTS.md)
 - `src/services/emoji/` – EmojiService (SQLite-backed emoji reaction tracking + leaderboard queries) - [See AGENTS.md](src/services/emoji/AGENTS.md)
+- `src/services/github/` – GithubService (create/search issues on an allowlisted set of repos) - [See AGENTS.md](src/services/github/AGENTS.md)
 - `src/services/memory/` – MemoryService (SQLite-backed memory + preferences) - [See AGENTS.md](src/services/memory/AGENTS.md)
 - `src/services/cron/` – CronService (scheduled jobs) - [See AGENTS.md](src/services/cron/AGENTS.md)
 - `src/test-utils/` – Shared test utilities (`createMockMessage.ts`, `mock.ts`, `consoleMocks.ts`)
@@ -56,7 +57,7 @@ Other files and directories follow standard Node.js/TypeScript project conventio
 
 - Copy `.env.example` to `.env` and configure required credentials.
 - Required: `DISCORD_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_APP_ID`, `DISCORD_STARTUP_CHANNEL_ID`, `DISCORD_MOTD_CHANNEL_ID`, `OPENAI_API_KEY`, `OPENAI_IMAGE_MODEL`, `ROOIVALK_MOTD_CRON`.
-- Optional: `OPENAI_MODEL` (chat), `XAI_API_KEY` + `XAI_MODEL` (chat → xAI), `XAI_IMAGE_MODEL` (image gen → xAI), `STEAM_API_KEY` (nightly Steam app catalogue sync), `ROOIVALK_DB_PATH` (default `./data/rooivalk.db`), `ROOIVALK_LEADERBOARD_CRON`, `DISCORD_ALLOWED_APPS` (comma-separated bot ids permitted to interact), `LOG_LEVEL` (`debug` enables prompt-metric logging).
+- Optional: `OPENAI_MODEL` (chat), `XAI_API_KEY` + `XAI_MODEL` (chat → xAI), `XAI_IMAGE_MODEL` (image gen → xAI), `STEAM_API_KEY` (nightly Steam app catalogue sync), `GITHUB_TOKEN` (enables the create/search GitHub issue tools on the repos allowlisted in `GITHUB_REPOS`), `ROOIVALK_DB_PATH` (default `./data/rooivalk.db`), `ROOIVALK_LEADERBOARD_CRON`, `DISCORD_ALLOWED_APPS` (comma-separated bot ids permitted to interact), `LOG_LEVEL` (`debug` enables prompt-metric logging).
 - Channel-specific chat behaviour (e.g. field hospital) is configured as profiles in `config/profiles.json`, not env — see `src/services/chat/AGENTS.md`.
 
 ## Coding Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# CLAUDE.md
-
-For project structure, architecture, coding conventions, and development commands, see [AGENTS.md](AGENTS.md) and the per-service `AGENTS.md` files.
+@AGENTS.md

--- a/config/github_issue_template.md
+++ b/config/github_issue_template.md
@@ -1,0 +1,22 @@
+When calling `create_github_issue`, structure the `body` using this template.
+Fill in each section from the conversation context; do not invent details the
+user didn't provide.
+
+## Description
+A clear, concise summary of the bug or feature request.
+
+## Steps to Reproduce
+1. ...
+2. ...
+
+Omit this section entirely for feature requests.
+
+## Expected Behavior
+What should happen.
+
+## Actual Behavior
+What actually happens instead. Omit this section entirely for feature requests.
+
+## Additional Context
+Anything else relevant: links, error messages, or details mentioned in the
+conversation. Omit this section if there's nothing to add.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "overrides": {
       "vite": "^7.3.2",
       "ws": "^8.20.1"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -11,6 +11,7 @@ import {
   CONFIG_FILE_LEADERBOARD,
   CONFIG_FILE_MOTD,
   CONFIG_FILE_MOTD_IMAGE_PROMPT,
+  CONFIG_FILE_GITHUB_ISSUE_TEMPLATE,
 } from '../constants.ts';
 import type { InMemoryConfig } from '../types.ts';
 import { loadInstructions, loadMessageList } from './messages.ts';
@@ -33,6 +34,7 @@ export const loadConfig = async (): Promise<InMemoryConfig> => {
     toolRoles,
     motd,
     motdImagePrompt,
+    githubIssueTemplate,
   ] = await Promise.all([
     loadMessageList(CONFIG_FILE_ERRORS),
     loadMessageList(CONFIG_FILE_GREETINGS),
@@ -48,6 +50,7 @@ export const loadConfig = async (): Promise<InMemoryConfig> => {
     loadToolRoles(),
     loadInstructions(CONFIG_FILE_MOTD),
     loadInstructions(CONFIG_FILE_MOTD_IMAGE_PROMPT),
+    loadInstructions(CONFIG_FILE_GITHUB_ISSUE_TEMPLATE),
   ]);
 
   const profileInstructions = await loadProfileInstructions(profiles);
@@ -70,6 +73,7 @@ export const loadConfig = async (): Promise<InMemoryConfig> => {
     toolRoles,
     motd,
     motdImagePrompt,
+    githubIssueTemplate,
   };
 
   return config;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,17 @@ export const YR_USER_AGENT = 'rooivalk github.com/fjlaubscher/rooivalk';
 export const STEAM_USER_AGENT = 'rooivalk github.com/fjlaubscher/rooivalk';
 export const STEAM_CC = 'ZA';
 
+// GitHub related constants
+export const GITHUB_USER_AGENT = 'rooivalk github.com/fjlaubscher/rooivalk';
+export const GITHUB_API_BASE = 'https://api.github.com';
+
+// Allowlisted repos the create/search issue tools may operate on. Key is the
+// short slug the model picks; value is the `owner/repo` GitHub identifier.
+export const GITHUB_REPOS: Record<string, string> = {
+  warren: 'fjlaubscher/warren',
+  rooivalk: 'fjlaubscher/rooivalk',
+};
+
 export const YR_COORDINATES: Record<string, WeatherLocation> = {
   BONNIEVALE: {
     name: 'Bonnievale, South Africa',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,7 @@ export const CONFIG_FILE_PROFILES = 'profiles.json';
 export const CONFIG_FILE_TOOL_ROLES = 'tool-roles.json';
 export const CONFIG_FILE_MOTD = 'motd.md';
 export const CONFIG_FILE_MOTD_IMAGE_PROMPT = 'motd-image-prompt.md';
+export const CONFIG_FILE_GITHUB_ISSUE_TEMPLATE = 'github_issue_template.md';
 
 // Each channel profile's instructions live in its own markdown file, addressed
 // by profile name. Deployment-specific, separate from the per-provider defaults.
@@ -81,6 +82,7 @@ export const GITHUB_API_BASE = 'https://api.github.com';
 export const GITHUB_REPOS: Record<string, string> = {
   warren: 'fjlaubscher/warren',
   rooivalk: 'fjlaubscher/rooivalk',
+  depot: 'fjlaubscher/depot',
 };
 
 export const YR_COORDINATES: Record<string, WeatherLocation> = {

--- a/src/services/chat/AGENTS.md
+++ b/src/services/chat/AGENTS.md
@@ -106,6 +106,16 @@ supplies its own client, `requireChatModel()`, and `this._config.motdImagePrompt
 `RooivalkService` consumes this via the `ImageService` union (see
 `src/services/rooivalk/AGENTS.md`).
 
+## GitHub Issue Template
+
+`config/github_issue_template.md` is hot-reloaded into
+`config.githubIssueTemplate` like every other `config/*.md` file. Both
+`OpenAIService.createResponse` and `XAIService.createResponse` append it to the
+system instructions — but only when a `toolExecutor` is passed in (i.e. only for
+the main chat flow, not one-shot calls like MOTD generation) — so the model has
+a consistent structure to follow when it calls `create_github_issue`. Editing
+the file changes the template with no redeploy.
+
 ## Role-Based Tool Permissions
 
 Tool access can be gated by Discord role, independent of channel profiles.

--- a/src/services/chat/tool-names.ts
+++ b/src/services/chat/tool-names.ts
@@ -11,4 +11,6 @@ export const TOOL_NAMES = Object.freeze({
   QUERY_SQLITE: 'query_sqlite',
   DESCRIBE_SCHEMA: 'describe_schema',
   GENERATE_IMAGE: 'generate_image',
+  CREATE_GITHUB_ISSUE: 'create_github_issue',
+  SEARCH_GITHUB_ISSUES: 'search_github_issues',
 });

--- a/src/services/github/AGENTS.md
+++ b/src/services/github/AGENTS.md
@@ -1,0 +1,25 @@
+# GithubService Agent Guidelines
+
+## Overview
+
+GithubService creates and searches issues on an allowlisted set of Francois's own GitHub repos, backing the `create_github_issue` and `search_github_issues` chat tools. Plain `fetch` against the GitHub REST API — no SDK, same pattern as `SteamService`/`YrService`.
+
+## Key Responsibilities
+
+- Creating issues via `POST /repos/{owner}/{repo}/issues`
+- Searching issues via `GET /search/issues`
+- Repo allowlist (short slug → `owner/repo`) lives in `GITHUB_REPOS` (`src/constants.ts`) — the executor resolves the enum key to a slug before calling this service
+
+## Architecture Notes
+
+- `GITHUB_TOKEN` is optional; if unset, both methods throw `GITHUB_TOKEN not configured` so the executor can surface a graceful error instead of crashing
+- Results are capped to 10 items in `searchIssues`
+- All types live in `src/services/github/types.ts`
+
+## Common Tasks
+
+| Task                        | File(s)                                     | Notes                                                  |
+| --------------------------- | ------------------------------------------- | ------------------------------------------------------ |
+| Add a repo to the allowlist | `src/constants.ts` (`GITHUB_REPOS`)         | No code change beyond the map entry                    |
+| Adjust returned fields      | `src/services/github/index.ts` + `types.ts` | Keep `GithubIssueSummary`/`CreatedGithubIssue` minimal |
+| Gate a tool by role         | `config/tool-roles.json`                    | No code change — add the tool name under a role id     |

--- a/src/services/github/AGENTS.md
+++ b/src/services/github/AGENTS.md
@@ -15,6 +15,7 @@ GithubService creates and searches issues on an allowlisted set of Francois's ow
 - `GITHUB_TOKEN` is optional; if unset, both methods throw `GITHUB_TOKEN not configured` so the executor can surface a graceful error instead of crashing
 - Results are capped to 10 items in `searchIssues`
 - All types live in `src/services/github/types.ts`
+- The chat model composes the `create_github_issue` body per `config/github_issue_template.md` (hot-reloaded into `config.githubIssueTemplate` — see `src/services/chat/AGENTS.md#github-issue-template`), not per any formatting logic in this service
 
 ## Common Tasks
 

--- a/src/services/github/index.test.ts
+++ b/src/services/github/index.test.ts
@@ -128,6 +128,58 @@ describe('GithubService', () => {
       );
     });
 
+    it('omits the state qualifier entirely when state is "all"', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+      await service.searchIssues('fjlaubscher/warren', null, 'all');
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain('q=repo%3Afjlaubscher%2Fwarren+type%3Aissue');
+      expect(url).not.toContain('state%3A');
+    });
+
+    it('strips repo/org/user/owner qualifiers from the free-text query', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+      await service.searchIssues(
+        'fjlaubscher/warren',
+        'login bug repo:other/repo org:someorg',
+        'open',
+      );
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const q = decodeURIComponent(new URL(url).searchParams.get('q')!);
+      expect(q).toBe('repo:fjlaubscher/warren type:issue state:open login bug');
+    });
+
+    it('strips a boolean OR from the free-text query', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+      await service.searchIssues(
+        'fjlaubscher/warren',
+        'login OR crash',
+        'open',
+      );
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const q = decodeURIComponent(new URL(url).searchParams.get('q')!);
+      expect(q).toBe(
+        'repo:fjlaubscher/warren type:issue state:open login crash',
+      );
+    });
+
     it('throws when the API returns a non-ok HTTP status', async () => {
       const service = new GithubService('test-token');
       mockFetch.mockResolvedValue({

--- a/src/services/github/index.test.ts
+++ b/src/services/github/index.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import GithubService from './index.ts';
+
+const mockFetch = vi.fn();
+
+describe('GithubService', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('without a token', () => {
+    it('throws on createIssue', async () => {
+      const service = new GithubService();
+      await expect(
+        service.createIssue('fjlaubscher/warren', 'title'),
+      ).rejects.toThrow('GITHUB_TOKEN not configured');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws on searchIssues', async () => {
+      const service = new GithubService();
+      await expect(
+        service.searchIssues('fjlaubscher/warren', null),
+      ).rejects.toThrow('GITHUB_TOKEN not configured');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createIssue', () => {
+    it('posts to the right URL with title/body and parses number/url', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ number: 42, html_url: 'https://example.com/42' }),
+      });
+
+      const result = await service.createIssue(
+        'fjlaubscher/warren',
+        'Bug title',
+        'Bug body',
+      );
+
+      expect(result).toEqual({ number: 42, url: 'https://example.com/42' });
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(
+        'https://api.github.com/repos/fjlaubscher/warren/issues',
+      );
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body)).toEqual({
+        title: 'Bug title',
+        body: 'Bug body',
+      });
+      expect(options.headers.Authorization).toBe('Bearer test-token');
+    });
+
+    it('throws when the API returns a non-ok HTTP status', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      });
+
+      await expect(
+        service.createIssue('fjlaubscher/warren', 'title'),
+      ).rejects.toThrow('createIssue failed: 403');
+    });
+  });
+
+  describe('searchIssues', () => {
+    it('builds the correct q= and maps items', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              number: 1,
+              title: 'Login bug',
+              state: 'open',
+              html_url: 'https://example.com/1',
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+        }),
+      });
+
+      const result = await service.searchIssues(
+        'fjlaubscher/warren',
+        'login',
+        'open',
+      );
+
+      expect(result).toEqual([
+        {
+          number: 1,
+          title: 'Login bug',
+          state: 'open',
+          url: 'https://example.com/1',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain(
+        'q=repo%3Afjlaubscher%2Fwarren+type%3Aissue+state%3Aopen+login',
+      );
+    });
+
+    it('defaults state to open and omits query when not provided', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+      await service.searchIssues('fjlaubscher/warren', null);
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain(
+        'q=repo%3Afjlaubscher%2Fwarren+type%3Aissue+state%3Aopen',
+      );
+    });
+
+    it('throws when the API returns a non-ok HTTP status', async () => {
+      const service = new GithubService('test-token');
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+      });
+
+      await expect(
+        service.searchIssues('fjlaubscher/warren', null),
+      ).rejects.toThrow('searchIssues failed: 422');
+    });
+  });
+});

--- a/src/services/github/index.ts
+++ b/src/services/github/index.ts
@@ -1,0 +1,89 @@
+import { GITHUB_API_BASE, GITHUB_USER_AGENT } from '../../constants.ts';
+import type {
+  CreateIssueResponse,
+  CreatedGithubIssue,
+  GithubIssueState,
+  GithubIssueSummary,
+  SearchIssuesResponse,
+} from './types.ts';
+
+const SEARCH_ISSUES_LIMIT = 10;
+
+class GithubService {
+  private _token?: string;
+
+  constructor(token?: string) {
+    this._token = token;
+  }
+
+  private headers(): Record<string, string> {
+    if (!this._token) {
+      throw new Error('GITHUB_TOKEN not configured');
+    }
+
+    return {
+      Authorization: `Bearer ${this._token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': GITHUB_USER_AGENT,
+    };
+  }
+
+  public async createIssue(
+    slug: string,
+    title: string,
+    body?: string,
+  ): Promise<CreatedGithubIssue> {
+    const response = await fetch(`${GITHUB_API_BASE}/repos/${slug}/issues`, {
+      method: 'POST',
+      headers: {
+        ...this.headers(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title, body }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `createIssue failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as CreateIssueResponse;
+    return { number: data.number, url: data.html_url };
+  }
+
+  public async searchIssues(
+    slug: string,
+    query: string | null | undefined,
+    state: GithubIssueState = 'open',
+  ): Promise<GithubIssueSummary[]> {
+    const qParts = [`repo:${slug}`, 'type:issue', `state:${state}`];
+    if (query) {
+      qParts.push(query);
+    }
+
+    const url = new URL(`${GITHUB_API_BASE}/search/issues`);
+    url.searchParams.set('q', qParts.join(' '));
+    url.searchParams.set('per_page', String(SEARCH_ISSUES_LIMIT));
+
+    const response = await fetch(url.toString(), { headers: this.headers() });
+
+    if (!response.ok) {
+      throw new Error(
+        `searchIssues failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as SearchIssuesResponse;
+    return data.items.slice(0, SEARCH_ISSUES_LIMIT).map((item) => ({
+      number: item.number,
+      title: item.title,
+      state: item.state,
+      url: item.html_url,
+      updated_at: item.updated_at,
+    }));
+  }
+}
+
+export default GithubService;

--- a/src/services/github/index.ts
+++ b/src/services/github/index.ts
@@ -9,6 +9,21 @@ import type {
 
 const SEARCH_ISSUES_LIMIT = 10;
 
+// Strips qualifiers/operators a caller could use to widen a search beyond the
+// repo we already scoped it to via `repo:${slug}` (e.g. `repo:other/repo`,
+// `org:x`, or a boolean `OR`). GitHub only treats `OR` as boolean when
+// uppercase, so lowercase "or" in free text is left untouched.
+const SCOPE_WIDENING_QUALIFIER = /\b(?:repo|org|user|owner):\S+/gi;
+const BOOLEAN_OR = /\bOR\b/g;
+
+function sanitizeSearchQuery(query: string): string {
+  return query
+    .replace(SCOPE_WIDENING_QUALIFIER, '')
+    .replace(BOOLEAN_OR, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 class GithubService {
   private _token?: string;
 
@@ -58,9 +73,13 @@ class GithubService {
     query: string | null | undefined,
     state: GithubIssueState = 'open',
   ): Promise<GithubIssueSummary[]> {
-    const qParts = [`repo:${slug}`, 'type:issue', `state:${state}`];
-    if (query) {
-      qParts.push(query);
+    const qParts = [`repo:${slug}`, 'type:issue'];
+    if (state !== 'all') {
+      qParts.push(`state:${state}`);
+    }
+    const sanitizedQuery = query ? sanitizeSearchQuery(query) : '';
+    if (sanitizedQuery) {
+      qParts.push(sanitizedQuery);
     }
 
     const url = new URL(`${GITHUB_API_BASE}/search/issues`);
@@ -76,7 +95,7 @@ class GithubService {
     }
 
     const data = (await response.json()) as SearchIssuesResponse;
-    return data.items.slice(0, SEARCH_ISSUES_LIMIT).map((item) => ({
+    return data.items.map((item) => ({
       number: item.number,
       title: item.title,
       state: item.state,

--- a/src/services/github/types.ts
+++ b/src/services/github/types.ts
@@ -1,0 +1,31 @@
+export type CreateIssueResponse = {
+  number: number;
+  html_url: string;
+};
+
+export type SearchIssuesItem = {
+  number: number;
+  title: string;
+  state: string;
+  html_url: string;
+  updated_at: string;
+};
+
+export type SearchIssuesResponse = {
+  items: SearchIssuesItem[];
+};
+
+export type GithubIssueSummary = {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  updated_at: string;
+};
+
+export type CreatedGithubIssue = {
+  number: number;
+  url: string;
+};
+
+export type GithubIssueState = 'open' | 'closed' | 'all';

--- a/src/services/openai/index.test.ts
+++ b/src/services/openai/index.test.ts
@@ -335,6 +335,39 @@ describe('OpenAIService', () => {
     });
   });
 
+  describe('github issue template injection', () => {
+    it('appends the template when a toolExecutor is provided', async () => {
+      responsesCreateMock.mockResolvedValueOnce({
+        output_text: 'ok',
+        output: [],
+      });
+
+      await service.createResponse(
+        'test user',
+        'hi',
+        null,
+        null,
+        vi.fn() as any,
+      );
+
+      const callArgs = responsesCreateMock.mock.calls[0]![0];
+      expect(callArgs.instructions).toContain('[GitHub issue template');
+      expect(callArgs.instructions).toContain(MOCK_CONFIG.githubIssueTemplate);
+    });
+
+    it('omits the template when no toolExecutor is provided', async () => {
+      responsesCreateMock.mockResolvedValueOnce({
+        output_text: 'ok',
+        output: [],
+      });
+
+      await service.createResponse('test user', 'hi');
+
+      const callArgs = responsesCreateMock.mock.calls[0]![0];
+      expect(callArgs.instructions).not.toContain('[GitHub issue template');
+    });
+  });
+
   describe('createImage', () => {
     it('returns base64 image on success', async () => {
       imagesGenerateMock.mockResolvedValueOnce({ data: [{ b64_json: 'img' }] });

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -97,6 +97,10 @@ class OpenAIService {
         instructions += renderPreferences(preferences);
       }
 
+      if (toolExecutor && this._config.githubIssueTemplate) {
+        instructions += `\n\n[GitHub issue template — follow this when calling create_github_issue]\n${this._config.githubIssueTemplate}`;
+      }
+
       // Attach the speaker identity to the user turn itself rather than a
       // separate system message. With previous_response_id the model treats
       // system messages as conversation-level framing and anchors on the first

--- a/src/services/openai/tools.ts
+++ b/src/services/openai/tools.ts
@@ -1,6 +1,6 @@
 import type OpenAI from 'openai';
 
-import { YR_COORDINATES } from '../../constants.ts';
+import { GITHUB_REPOS, YR_COORDINATES } from '../../constants.ts';
 import { TOOL_NAMES } from '../chat/tool-names.ts';
 
 export const QUERY_SQLITE_SCHEMA = {
@@ -281,6 +281,62 @@ export const FUNCTION_TOOLS: OpenAI.Responses.Tool[] = [
         },
       },
       required: ['query', 'store'],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: 'function',
+    name: TOOL_NAMES.CREATE_GITHUB_ISSUE,
+    description:
+      'File a new GitHub issue on one of a predefined set of repos. Only use when the user explicitly asks to file, open, or report an issue/bug. Only the listed repos are available.',
+    strict: true,
+    parameters: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          enum: Object.keys(GITHUB_REPOS),
+          description: 'The repo to file the issue on.',
+        },
+        title: {
+          type: 'string',
+          description: 'A short, descriptive issue title.',
+        },
+        body: {
+          type: ['string', 'null'],
+          description: 'The issue body/description. Null for no body.',
+        },
+      },
+      required: ['repo', 'title', 'body'],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: 'function',
+    name: TOOL_NAMES.SEARCH_GITHUB_ISSUES,
+    description:
+      'Search or list GitHub issues on one of a predefined set of repos. Use to check whether a bug/issue exists or has already been fixed.',
+    strict: true,
+    parameters: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          enum: Object.keys(GITHUB_REPOS),
+          description: 'The repo to search issues on.',
+        },
+        query: {
+          type: ['string', 'null'],
+          description:
+            'Free-text search terms. Null to list without filtering.',
+        },
+        state: {
+          type: 'string',
+          enum: ['open', 'closed', 'all'],
+          description: 'Filter issues by state.',
+        },
+      },
+      required: ['repo', 'query', 'state'],
       additionalProperties: false,
     },
   },

--- a/src/services/rooivalk/index.ts
+++ b/src/services/rooivalk/index.ts
@@ -34,6 +34,7 @@ import {
 import type { ChatService, ImageService } from '../chat/index.ts';
 import DiscordService from '../discord/index.ts';
 import EmojiService from '../emoji/index.ts';
+import GithubService from '../github/index.ts';
 import MemoryService from '../memory/index.ts';
 import PeapixService from '../peapix/index.ts';
 import SteamService from '../steam/index.ts';
@@ -163,6 +164,7 @@ class Rooivalk {
   protected _emoji: EmojiService;
   protected _memory: MemoryService;
   protected _steam: SteamService;
+  protected _github: GithubService;
   private _allowedAppIds: string[];
 
   constructor(
@@ -176,6 +178,7 @@ class Rooivalk {
     memoryService?: MemoryService,
     steamService?: SteamService,
     emojiService?: EmojiService,
+    githubService?: GithubService,
   ) {
     this._config = config;
     this._discord = discordService ?? new DiscordService(this._config);
@@ -197,6 +200,7 @@ class Rooivalk {
     this._emoji =
       emojiService ??
       new EmojiService(process.env.ROOIVALK_DB_PATH ?? './data/rooivalk.db');
+    this._github = githubService ?? new GithubService(process.env.GITHUB_TOKEN);
 
     // Parse DISCORD_ALLOWED_APPS once and store
     const allowedAppsEnv = process.env.DISCORD_ALLOWED_APPS;
@@ -377,6 +381,7 @@ class Rooivalk {
       image: this._openai,
       memory: this._memory,
       steam: this._steam,
+      github: this._github,
       createThread: (msg, name) => this.createRooivalkThread(msg, name),
       toolRoles: this._config.toolRoles,
     });

--- a/src/services/rooivalk/tool-executor.test.ts
+++ b/src/services/rooivalk/tool-executor.test.ts
@@ -22,6 +22,7 @@ function buildContext(
     discord: { getRooivalkResponse: () => DENIED_MESSAGE } as any,
     memory: {} as any,
     steam: {} as any,
+    github: {} as any,
     image: {} as any,
     createThread: vi.fn(),
     ...overrides,
@@ -147,5 +148,111 @@ describe('buildToolExecutor role-based tool permissions', () => {
 
     expect(runBashMock).toHaveBeenCalledWith('ls');
     expect(result.deniedMessage).toBeUndefined();
+  });
+});
+
+describe('buildToolExecutor github tools', () => {
+  it('creates an issue on a known repo and appends the attribution footer', async () => {
+    const createIssue = vi
+      .fn()
+      .mockResolvedValue({ number: 1, url: 'https://example.com/1' });
+    const execute = buildToolExecutor(
+      buildContext({ github: { createIssue } as any }),
+    );
+
+    const result = await execute(TOOL_NAMES.CREATE_GITHUB_ISSUE, {
+      repo: 'rooivalk',
+      title: 'Bug title',
+      body: 'Bug body',
+    });
+
+    expect(createIssue).toHaveBeenCalledWith(
+      'fjlaubscher/rooivalk',
+      'Bug title',
+      expect.stringContaining('Bug body\n\n_Filed via rooivalk by'),
+    );
+    expect(JSON.parse(result.output)).toEqual({
+      number: 1,
+      url: 'https://example.com/1',
+    });
+  });
+
+  it('returns an error for create_github_issue on an unknown repo', async () => {
+    const createIssue = vi.fn();
+    const execute = buildToolExecutor(
+      buildContext({ github: { createIssue } as any }),
+    );
+
+    const result = await execute(TOOL_NAMES.CREATE_GITHUB_ISSUE, {
+      repo: 'not-a-repo',
+      title: 'Bug title',
+      body: null,
+    });
+
+    expect(createIssue).not.toHaveBeenCalled();
+    expect(JSON.parse(result.output)).toEqual({
+      error: 'Unknown repo: not-a-repo',
+    });
+  });
+
+  it('searches issues on a known repo, defaulting state to open', async () => {
+    const searchIssues = vi.fn().mockResolvedValue([
+      {
+        number: 2,
+        title: 'Login bug',
+        state: 'open',
+        url: 'https://example.com/2',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    const execute = buildToolExecutor(
+      buildContext({ github: { searchIssues } as any }),
+    );
+
+    const result = await execute(TOOL_NAMES.SEARCH_GITHUB_ISSUES, {
+      repo: 'warren',
+      query: 'login',
+      state: null,
+    });
+
+    expect(searchIssues).toHaveBeenCalledWith(
+      'fjlaubscher/warren',
+      'login',
+      'open',
+    );
+    expect(JSON.parse(result.output)).toHaveLength(1);
+  });
+
+  it('returns an error for search_github_issues on an unknown repo', async () => {
+    const searchIssues = vi.fn();
+    const execute = buildToolExecutor(
+      buildContext({ github: { searchIssues } as any }),
+    );
+
+    const result = await execute(TOOL_NAMES.SEARCH_GITHUB_ISSUES, {
+      repo: 'not-a-repo',
+      query: null,
+      state: null,
+    });
+
+    expect(searchIssues).not.toHaveBeenCalled();
+    expect(JSON.parse(result.output)).toEqual({
+      error: 'Unknown repo: not-a-repo',
+    });
+  });
+
+  it('wraps a thrown error from createIssue in the error output', async () => {
+    const createIssue = vi.fn().mockRejectedValue(new Error('boom'));
+    const execute = buildToolExecutor(
+      buildContext({ github: { createIssue } as any }),
+    );
+
+    const result = await execute(TOOL_NAMES.CREATE_GITHUB_ISSUE, {
+      repo: 'rooivalk',
+      title: 'Bug title',
+      body: null,
+    });
+
+    expect(JSON.parse(result.output)).toEqual({ error: 'boom' });
   });
 });

--- a/src/services/rooivalk/tool-executor.ts
+++ b/src/services/rooivalk/tool-executor.ts
@@ -1,11 +1,14 @@
 import type { Message, ThreadChannel } from 'discord.js';
 
+import { GITHUB_REPOS } from '../../constants.ts';
 import { runBash } from '../bash/index.ts';
 import { TOOL_NAMES } from '../chat/tool-names.ts';
 import type { ImageService } from '../chat/index.ts';
 import { QUERY_SQLITE_SCHEMA } from '../openai/tools.ts';
 import { validateQuerySql } from './query-sqlite-guard.ts';
 import type DiscordService from '../discord/index.ts';
+import type GithubService from '../github/index.ts';
+import type { GithubIssueState } from '../github/types.ts';
 import type MemoryService from '../memory/index.ts';
 import type { MemoryKind } from '../memory/index.ts';
 import type SteamService from '../steam/index.ts';
@@ -22,6 +25,7 @@ export type ToolExecutorContext = {
   discord: DiscordService;
   memory: MemoryService;
   steam: SteamService;
+  github: GithubService;
   image: ImageService;
   createThread: (
     message: Message<boolean>,
@@ -40,7 +44,8 @@ function errorOutput(err: unknown): ToolExecutionResult {
 }
 
 export function buildToolExecutor(ctx: ToolExecutorContext): ToolExecutor {
-  const { message, yr, discord, memory, steam, image, createThread } = ctx;
+  const { message, yr, discord, memory, steam, github, image, createThread } =
+    ctx;
 
   // Invert the role -> tools permission map into tool -> allowed role ids, so a
   // call can be checked with a single lookup. A tool absent from this map is
@@ -199,6 +204,48 @@ export function buildToolExecutor(ctx: ToolExecutorContext): ToolExecutor {
           }
 
           return { output: JSON.stringify(details) };
+        } catch (err) {
+          return errorOutput(err);
+        }
+      }
+      case TOOL_NAMES.CREATE_GITHUB_ISSUE: {
+        const repo = args.repo as string;
+        const slug = GITHUB_REPOS[repo];
+        if (!slug) {
+          return {
+            output: JSON.stringify({ error: `Unknown repo: ${repo}` }),
+          };
+        }
+
+        try {
+          const title = args.title as string;
+          const body = args.body as string | null;
+          const author = message.author.displayName ?? message.author.username;
+          const footer = `\n\n_Filed via rooivalk by ${author}_`;
+          const issue = await github.createIssue(
+            slug,
+            title,
+            (body ?? '') + footer,
+          );
+          return { output: JSON.stringify(issue) };
+        } catch (err) {
+          return errorOutput(err);
+        }
+      }
+      case TOOL_NAMES.SEARCH_GITHUB_ISSUES: {
+        const repo = args.repo as string;
+        const slug = GITHUB_REPOS[repo];
+        if (!slug) {
+          return {
+            output: JSON.stringify({ error: `Unknown repo: ${repo}` }),
+          };
+        }
+
+        try {
+          const query = args.query as string | null;
+          const state = (args.state as GithubIssueState | null) ?? 'open';
+          const issues = await github.searchIssues(slug, query, state);
+          return { output: JSON.stringify(issues) };
         } catch (err) {
           return errorOutput(err);
         }

--- a/src/services/xai/index.ts
+++ b/src/services/xai/index.ts
@@ -93,6 +93,10 @@ class XAIService {
         instructions += renderPreferences(preferences);
       }
 
+      if (toolExecutor && this._config.githubIssueTemplate) {
+        instructions += `\n\n[GitHub issue template — follow this when calling create_github_issue]\n${this._config.githubIssueTemplate}`;
+      }
+
       // Attach the speaker identity to the user turn itself rather than a
       // separate system message. With previous_response_id the model treats
       // system messages as conversation-level framing and anchors on the first

--- a/src/test-utils/mock.ts
+++ b/src/test-utils/mock.ts
@@ -30,4 +30,5 @@ export const MOCK_CONFIG: InMemoryConfig = {
   toolRoles: {},
   motd: 'Message of the day',
   motdImagePrompt: 'Craft an image prompt for {{LOCATION}}',
+  githubIssueTemplate: 'Follow this issue template.',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,8 @@ export type InMemoryConfig = {
   motd: string;
   /** Instructions the chat model follows to craft the daily MOTD image prompt. */
   motdImagePrompt: string;
+  /** Template the chat model follows when composing a `create_github_issue` body. */
+  githubIssueTemplate: string;
 };
 
 export type ResponseType =


### PR DESCRIPTION
## Description
Adds two new chat tools — `create_github_issue` and `search_github_issues` — so rooivalk can file and check on GitHub issues for an allowlisted set of Francois's own repos (`warren`, `rooivalk`, `depot`) directly from Discord, e.g. answering "has my bug been fixed?" or filing a new one on request.

- New `GithubService` (`src/services/github/`) mirrors `SteamService`'s plain-`fetch` pattern — no new npm dependency. `GITHUB_TOKEN` is optional; both methods throw a clear error if it's missing, which the tool executor surfaces gracefully instead of crashing.
- Repo allowlist (`GITHUB_REPOS`) lives in `src/constants.ts` as a code constant (like `YR_COORDINATES`), not a hot-reload config — adding a repo is a one-line change.
- Follows the established 3-file tool pattern: tool name (`tool-names.ts`) → schema (`openai/tools.ts`, shared by OpenAI + xAI) → executor case (`tool-executor.ts`).
- Unrestricted by default; can be role-gated later via `config/tool-roles.json` with zero code change.
- Added a hot-swappable `config/github_issue_template.md` (loaded/watched like `motd.md`/`boast.md`) that's appended to the system instructions whenever a tool executor is present, so the model has a consistent structure to follow when composing an issue body.
- Also includes an unrelated small cleanup that was sitting in the working tree: simplified root `CLAUDE.md` to `@AGENTS.md`, and pinned `esbuild` as a pnpm built dependency in `package.json`.

## How to test
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (316 tests)
- [x] `pnpm prettier:check` passes
- [ ] Manual (needs a real `GITHUB_TOKEN` in `.env`): `@rooivalk file an issue on warren: "test issue"` and `@rooivalk is the login bug fixed in warren?` — confirm an issue is created and search returns results with links; verify a bogus repo name is rejected and that leaving `GITHUB_TOKEN` unset yields a graceful "not configured" reply rather than a crash.