### PR TITLE
Fail the deploy loudly when nvm is missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,8 +58,9 @@ jobs:
       - name: Install and restart on server
         run: |
           ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} << 'EOF'
+            set -e
             export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            \. "$NVM_DIR/nvm.sh"
 
             cd ${{ secrets.DEPLOY_PATH }}
             pnpm install


### PR DESCRIPTION
The remote step guarded the nvm source with `[ -s ... ] &&`, so a missing `~/.nvm` silently continued and surfaced as `pnpm: command not found` three lines later. Source it unconditionally under `set -e` so the step fails at the actual cause.

Shook out while switching the deploy key from `root` to `deploy` — the new user had no nvm, and the real error was invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)