### PR TITLE
Harden run_bash against shell injection and dotfile reads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,7 @@ jobs:
             --exclude='data/' \
             --exclude='profiles.json' \
             --exclude='profiles/' \
+            --exclude='tool-roles.json' \
             ./src ./config ./AGENTS.md ./package.json ./pnpm-lock.yaml ./tsconfig.json ./.nvmrc ./ecosystem.config.cjs \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:${{ secrets.DEPLOY_PATH }}
 

--- a/src/config/tool-roles.test.ts
+++ b/src/config/tool-roles.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
-import { parseToolRoles } from './tool-roles.ts';
+const mockReadFile = vi.hoisted(() => vi.fn());
+
+vi.mock('fs/promises', () => ({ readFile: mockReadFile }));
+
+import { loadToolRoles, parseToolRoles } from './tool-roles.ts';
 
 describe('parseToolRoles', () => {
   it('accepts a role mapping to known tool names', () => {
@@ -43,5 +47,30 @@ describe('parseToolRoles', () => {
     expect(() => parseToolRoles({ '123': ['run_bsah'] })).toThrow(
       /lists unknown tool name\(s\): run_bsah/,
     );
+  });
+});
+
+describe('loadToolRoles', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('warns that every tool is ungated when the file is missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error('missing'), { code: 'ENOENT' }),
+    );
+
+    await expect(loadToolRoles()).resolves.toEqual({});
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('run_bash'));
+  });
+
+  it('stays quiet when the file is present', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockReadFile.mockResolvedValue('{"123":["run_bash"]}');
+
+    await expect(loadToolRoles()).resolves.toEqual({ '123': ['run_bash'] });
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/config/tool-roles.ts
+++ b/src/config/tool-roles.ts
@@ -47,7 +47,13 @@ export const parseToolRoles = (parsed: unknown): ToolRoles => {
 /**
  * Loads the role-based tool permissions from `config/tool-roles.json`. The file
  * is deployment-specific (gitignored); a missing file means no tool is
- * restricted.
+ * restricted, which is a quiet way to expose `run_bash` to a whole guild — so
+ * it warns rather than starting up silently.
  */
 export const loadToolRoles = async (): Promise<ToolRoles> =>
-  loadJsonConfig(CONFIG_FILE_TOOL_ROLES, parseToolRoles, () => ({}));
+  loadJsonConfig(CONFIG_FILE_TOOL_ROLES, parseToolRoles, () => {
+    console.warn(
+      `[config/loader] No ${CONFIG_FILE_TOOL_ROLES} found — every tool, including ${TOOL_NAMES.RUN_BASH}, is available to every user`,
+    );
+    return {};
+  });

--- a/src/services/bash/index.test.ts
+++ b/src/services/bash/index.test.ts
@@ -81,6 +81,12 @@ describe('runBash', () => {
       'cat $(ls)',
       'ls > /tmp/out',
       'ls\nid',
+      // Quotes would be stripped by sh, smuggling a dotfile past the path check
+      "cat '.env'",
+      'cat ".env"',
+      // Tilde expands to $HOME, escaping the cwd sandbox
+      'cat ~/secrets',
+      'ls ~root',
     ])('rejects %j', async (command) => {
       const result = await runBash(command);
       expect(result.ok).toBe(false);

--- a/src/services/bash/index.test.ts
+++ b/src/services/bash/index.test.ts
@@ -72,6 +72,22 @@ describe('runBash', () => {
     });
   });
 
+  describe('shell metacharacters', () => {
+    it.each([
+      'ls; id',
+      'ls && id',
+      'ls | id',
+      'cat `id`',
+      'cat $(ls)',
+      'ls > /tmp/out',
+      'ls\nid',
+    ])('rejects %j', async (command) => {
+      const result = await runBash(command);
+      expect(result.ok).toBe(false);
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+
   describe('path sandboxing', () => {
     it('rejects absolute paths in file commands', async () => {
       const result = await runBash('cat /etc/passwd');
@@ -82,6 +98,23 @@ describe('runBash', () => {
     it('rejects directory traversal in file commands', async () => {
       const result = await runBash('cat ../../secrets');
       expect(result.ok).toBe(false);
+    });
+
+    it('rejects dotfiles holding secrets', async () => {
+      const result = await runBash('cat .env');
+      expect(result.ok).toBe(false);
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
+    it('rejects dotfiles nested in a path', async () => {
+      const result = await runBash('cat src/../.env');
+      expect(result.ok).toBe(false);
+    });
+
+    it('allows a bare . as a search root', async () => {
+      stubExec('match');
+      const result = await runBash('find . -name index.ts');
+      expect(result.ok).toBe(true);
     });
 
     it('allows flags alongside relative paths', async () => {

--- a/src/services/bash/index.ts
+++ b/src/services/bash/index.ts
@@ -26,12 +26,17 @@ const FILE_COMMANDS = new Set([
   'wc',
 ]);
 
-// The command runs through `sh -c`, so the allowlist below only means anything
-// if the shell can't be talked into running a second command. Anything that
-// chains, substitutes, or redirects is refused outright.
-// ponytail: a metacharacter denylist keeps `exec` and its glob expansion
-// working; switch to execFile with an argv array if this needs to get stricter.
-const SHELL_METACHARACTERS = /[;&|`$<>(){}\\\n\r]/;
+// The command runs through `sh -c`, which re-parses the string after `validate`
+// has already parsed it. Every character below is one the shell would rewrite
+// or act on, so banning them collapses that gap: what `validate` sees as a
+// whitespace-split argument is what `cat` receives. Chaining and substitution
+// go with it, and so do quotes (`cat '.env'` would otherwise reach the shell
+// as `.env`) and `~` (which expands to `$HOME`, escaping the cwd sandbox).
+// The cost is that quoted multi-word arguments are unavailable, e.g.
+// `grep -r "foo bar" src/` — acceptable for a log-poking tool.
+// ponytail: a denylist leaves glob expansion working; switch to execFile with
+// an argv array if the tool ever needs to accept quoted arguments.
+const SHELL_METACHARACTERS = /[;&|`$<>(){}\\'"~\n\r]/;
 
 function validate(command: string): string | null {
   if (SHELL_METACHARACTERS.test(command)) {

--- a/src/services/bash/index.ts
+++ b/src/services/bash/index.ts
@@ -26,7 +26,18 @@ const FILE_COMMANDS = new Set([
   'wc',
 ]);
 
+// The command runs through `sh -c`, so the allowlist below only means anything
+// if the shell can't be talked into running a second command. Anything that
+// chains, substitutes, or redirects is refused outright.
+// ponytail: a metacharacter denylist keeps `exec` and its glob expansion
+// working; switch to execFile with an argv array if this needs to get stricter.
+const SHELL_METACHARACTERS = /[;&|`$<>(){}\\\n\r]/;
+
 function validate(command: string): string | null {
+  if (SHELL_METACHARACTERS.test(command)) {
+    return 'Shell metacharacters are not allowed';
+  }
+
   const allowed = ALLOWED_PREFIXES.some(
     (prefix) => command === prefix || command.startsWith(`${prefix} `),
   );
@@ -41,8 +52,13 @@ function validate(command: string): string | null {
   if (FILE_COMMANDS.has(cmd)) {
     for (const arg of parts.slice(1)) {
       if (arg.startsWith('-')) continue;
-      if (arg.startsWith('/') || arg.includes('..')) {
-        return 'Absolute paths and directory traversal are not allowed';
+      if (arg.startsWith('/')) {
+        return 'Absolute paths are not allowed';
+      }
+      // Rejects `..` traversal and dotfiles (`.env` holds the bot's tokens) in
+      // any path segment, while still allowing a bare `.` as in `find . -name`.
+      if (arg.split('/').some((seg) => seg.startsWith('.') && seg !== '.')) {
+        return 'Directory traversal and dotfiles are not allowed';
       }
     }
   }


### PR DESCRIPTION
`run_bash` executes through `sh -c`, so the allowlist in `src/services/bash/index.ts` only ever inspected the first token. Two ways past it:

- `ls; id` — passes the prefix check, the shell runs both commands.
- `cat .env` — a relative path with no `..`, so the sandbox allowed it. Returns `DISCORD_TOKEN` and `OPENAI_API_KEY` in a Discord message.

Both are reachable by any guild member when `config/tool-roles.json` is absent, since `buildToolExecutor` treats a tool missing from the role map as unrestricted.

## Changes

- Reject shell metacharacters (`;&|\`$<>(){}\` and newlines) before the allowlist runs.
- Reject dotfile segments in file-command args. Subsumes the old `..` check; a bare `.` still works so `find . -name x` is unaffected.
- Exclude `config/tool-roles.json` from the deploy rsync. It's gitignored, so `--delete` would remove it from the server the moment it exists — an rsync `--exclude` also protects the file on the receiving side.

## Testing

`pnpm test` (323 pass), `pnpm typecheck`, `pnpm format`. New cases cover each injection form, `cat .env`, a nested `src/../.env`, and the bare-`.` allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)